### PR TITLE
feat: scaffold amap vue kit library

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.DS_Store
+coverage
+.temp
+.vscode
+.idea
+*.log
+dist
+packages/*/dist
+docs/.vitepress/cache
+docs/.vitepress/dist
+examples/*/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# amap-vue-kit
+# AMap Vue Kit
+
+Vue 3 components, composables, and tooling for the [AMap JSAPI 2.x](https://lbs.amap.com/api/javascript-api/summary).
+
+## Packages
+
+- `@amap-vue/shared` – shared loader, utilities, and types.
+- `@amap-vue/hooks` – type-safe composables (`useMap`, `useMarker`, `useOverlay`, `useMassMarkers`).
+- `@amap-vue/core` – declarative Vue components (`<AmapMap>`, `<AmapMarker>`, `<AmapInfoWindow>`, `<AmapPolyline>`, `<AmapPolygon>`, `<AmapCircle>`).
+- `docs` – VitePress documentation site with live demos.
+- `examples/basic` – Vite example app used for smoke testing.
+
+## Development
+
+```bash
+pnpm install
+pnpm lint
+pnpm test
+pnpm run build:all
+```
+
+### Docs
+
+```bash
+pnpm --filter @amap-vue/docs dev
+```
+
+### Example app
+
+```bash
+pnpm --filter amap-vue-example dev
+```
+
+Set `VITE_AMAP_KEY` in a `.env.local` file to load the live JSAPI map during development.
+
+## Releasing
+
+Use [Changesets](https://github.com/changesets/changesets) to manage versions and changelog entries.
+
+```bash
+pnpm changeset
+pnpm changeset version
+pnpm install
+pnpm changeset publish
+```

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,100 @@
+import { defineConfig } from 'vitepress'
+import { resolve } from 'node:path'
+
+export default defineConfig({
+  lang: 'en-US',
+  title: 'AMap Vue Kit',
+  description: 'Vue 3 components and composables for AMap JSAPI 2.x',
+  lastUpdated: true,
+  themeConfig: {
+    logo: '/logo.svg',
+    nav: [
+      { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Components', link: '/components/map' },
+      { text: 'Hooks', link: '/hooks/use-map' },
+      { text: 'Advanced', link: '/advanced/mass-markers' },
+      { text: 'Recipes', link: '/recipes/marker-clusters' },
+      { text: 'FAQ', link: '/faq' }
+    ],
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Getting Started', link: '/guide/getting-started' }
+          ]
+        }
+      ],
+      '/components/': [
+        {
+          text: 'Map',
+          items: [
+            { text: 'Map', link: '/components/map' },
+            { text: 'Marker', link: '/components/marker' },
+            { text: 'Info Window', link: '/components/info-window' },
+            { text: 'Polyline', link: '/components/polyline' },
+            { text: 'Polygon', link: '/components/polygon' },
+            { text: 'Circle', link: '/components/circle' }
+          ]
+        }
+      ],
+      '/hooks/': [
+        {
+          text: 'Hooks',
+          items: [
+            { text: 'useMap', link: '/hooks/use-map' },
+            { text: 'useMarker', link: '/hooks/use-marker' },
+            { text: 'useOverlay', link: '/hooks/use-overlay' }
+          ]
+        }
+      ],
+      '/advanced/': [
+        {
+          text: 'Advanced',
+          items: [
+            { text: 'Mass Markers', link: '/advanced/mass-markers' },
+            { text: 'Loca & Visualizations', link: '/advanced/loca' },
+            { text: 'Custom Tiles', link: '/advanced/custom-tiles' },
+            { text: 'Track Animation', link: '/advanced/track-animation' }
+          ]
+        },
+        {
+          text: 'Performance',
+          items: [
+            { text: 'Performance Guide', link: '/advanced/performance' }
+          ]
+        }
+      ],
+      '/recipes/': [
+        {
+          text: 'Recipes',
+          items: [
+            { text: 'Marker Clusters', link: '/recipes/marker-clusters' },
+            { text: 'Heatmap', link: '/recipes/heatmap' }
+          ]
+        }
+      ]
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/your-org/amap-vue-kit' }
+    ],
+    algolia: {
+      appId: 'YOUR_APP_ID',
+      apiKey: 'YOUR_SEARCH_KEY',
+      indexName: 'amap-vue-kit'
+    },
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © 2024 AMap Vue Kit'
+    }
+  },
+  vite: {
+    resolve: {
+      alias: {
+        '@amap-vue/core': resolve(__dirname, '../../packages/core/src'),
+        '@amap-vue/hooks': resolve(__dirname, '../../packages/hooks/src'),
+        '@amap-vue/shared': resolve(__dirname, '../../packages/shared/src')
+      }
+    }
+  }
+})

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,20 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import Core from '@amap-vue/core'
+import { loader } from '@amap-vue/shared'
+
+import './style.css'
+
+const theme: Theme = {
+  ...DefaultTheme,
+  enhanceApp({ app }) {
+    DefaultTheme.enhanceApp?.({ app })
+    app.use(Core)
+
+    const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+    if (key)
+      loader.config({ key })
+  }
+}
+
+export default theme

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,25 @@
+:root {
+  --amap-demo-border: rgba(60, 60, 67, 0.12);
+}
+
+.amap-demo {
+  border: 1px solid var(--amap-demo-border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.amap-demo__map {
+  width: 100%;
+  height: 320px;
+  position: relative;
+}
+
+.amap-demo__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 320px;
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-bg-alt);
+}

--- a/docs/advanced/custom-tiles.md
+++ b/docs/advanced/custom-tiles.md
@@ -1,0 +1,15 @@
+# Custom Tiles
+
+AMap supports custom tile layers for offline or domain-specific datasets. Use the map instance obtained from `ready` to add tile layers manually.
+
+```ts
+ready((map) => {
+  const layer = new AMap.TileLayer({
+    tileUrl: 'https://your-tile-server/{z}/{x}/{y}.png',
+    zIndex: 10
+  })
+  layer.setMap(map)
+})
+```
+
+Combine tile layers with Vue reactivity by storing references in `shallowRef` instances and updating options inside watchers.

--- a/docs/advanced/loca.md
+++ b/docs/advanced/loca.md
@@ -1,0 +1,14 @@
+# Loca & Visualizations
+
+Loca builds on top of JSAPI WebGL capabilities to render dense visualizations. The shared loader exposes a `loca` option to request the Loca script together with the base JSAPI.
+
+```ts
+import { loader } from '@amap-vue/shared'
+
+loader.config({
+  key: import.meta.env.VITE_AMAP_KEY,
+  loca: true
+})
+```
+
+From there you can instantiate `Loca.Container` instances inside `ready` callbacks. Future releases of AMap Vue Kit will ship dedicated helpers for common visualizations.

--- a/docs/advanced/mass-markers.md
+++ b/docs/advanced/mass-markers.md
@@ -1,0 +1,18 @@
+# Mass Markers
+
+Mass markers allow you to render tens of thousands of points efficiently by delegating rendering to the JSAPI.
+
+```ts
+import { useMassMarkers } from '@amap-vue/hooks'
+
+const mass = useMassMarkers(() => map.value, () => ({
+  data: points,
+  style: [{
+    url: 'https://a.amap.com/jsapi_demos/static/resource/img/markers/mark_b.png',
+    anchor: [6, 6],
+    size: [11, 11]
+  }]
+}))
+```
+
+Use the composable inside `ready` handlers to ensure the map exists before instantiation. Mass markers share the loader so additional plugins are only requested once.

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -1,0 +1,7 @@
+# Performance Guide
+
+1. **Batch updates** – prefer updating reactive props and watchers instead of imperatively mutating overlays in loops. The components queue updates and run them in microtasks.
+2. **Reuse the loader** – call `loader.config` once at bootstrap; avoid passing conflicting plugin arrays to every map to prevent redundant network requests.
+3. **Prefer Mass Markers** – for >1,000 points use `useMassMarkers` or cluster overlays; standard markers are intended for small batches.
+4. **Enable WebGL features** – set `viewMode="3D"` and configure `pitch` and `rotation` when using WebGL-based visualizations.
+5. **Use `destroy` hooks** – both components and composables clean up automatically, but when working with raw JSAPI instances always call `destroy` to prevent memory leaks.

--- a/docs/advanced/track-animation.md
+++ b/docs/advanced/track-animation.md
@@ -1,0 +1,14 @@
+# Track Animation
+
+Animate paths using the JSAPI `MoveAnimation` plugin or `AMap.Loca` trajectory layers. AMap Vue Kit does not abstract these APIs yet, but you can create them inside `ready` callbacks while reusing the loader and reactivity helpers.
+
+```ts
+ready((map) => {
+  map.plugin(['AMap.MoveAnimation'], () => {
+    const marker = new AMap.Marker({ position: path[0], map })
+    marker.moveAlong(path, { duration: 5000 })
+  })
+})
+```
+
+Consider combining track animations with `<AmapPolyline>` overlays to render the path outline while the marker moves along it.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This page is automatically generated from Changesets during release.
+
+```bash
+pnpm changeset
+pnpm changeset version
+```
+
+Run the commands above to create release notes and bump package versions.

--- a/docs/components/circle.md
+++ b/docs/components/circle.md
@@ -1,0 +1,32 @@
+# `<AmapCircle>`
+
+Render geofenced regions or coverage areas using circles.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `center` | `LngLatLike` | Circle center. |
+| `radius` | `number` | Radius in meters. |
+| `options` | `Partial<AMap.CircleOptions>` | Extra JSAPI options. |
+| `visible` | `boolean` | Controls visibility. |
+| `extData` | `any` | Arbitrary metadata. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.Circle` | Fired when the circle is created. |
+| `click` | `any` | Click events. |
+| `mouseover` | `any` | Pointer enter events. |
+| `mouseout` | `any` | Pointer leave events. |
+
+## Usage
+
+```vue
+<AmapCircle
+  :center="[116.397, 39.908]"
+  :radius="500"
+  :options="{ strokeColor: '#ff6a00', fillColor: 'rgba(255,106,0,0.1)' }"
+/>
+```

--- a/docs/components/info-window.md
+++ b/docs/components/info-window.md
@@ -1,0 +1,30 @@
+# `<AmapInfoWindow>`
+
+Display contextual information anchored to a map position. The component renders its default slot content inside the JSAPI info window.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `position` | `LngLatLike \| undefined` | Coordinates where the window opens. |
+| `isOpen` | `boolean` | Controls whether the window is open. |
+| `offset` | `AMap.Pixel \| [number, number]` | Pixel offset from the anchor. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.InfoWindow` | Fired when the info window is created. |
+
+## Usage
+
+```vue
+<AmapInfoWindow :position="[116.397, 39.908]" :is-open="showWindow">
+  <div class="popup">
+    <h4>Forbidden City</h4>
+    <p>Explore the imperial palace complex in central Beijing.</p>
+  </div>
+</AmapInfoWindow>
+```
+
+Toggle the `isOpen` prop or call `infoWindow.open(map, position)` on the exposed instance for imperative control.

--- a/docs/components/map.md
+++ b/docs/components/map.md
@@ -1,0 +1,55 @@
+# `<AmapMap>`
+
+`<AmapMap>` renders an interactive JSAPI map instance and provides context for nested overlays.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `center` | `LngLatLike \| undefined` | – | Initial center of the map. Accepts `[lng, lat]` or an `AMap.LngLat` instance. |
+| `zoom` | `number \| undefined` | – | Initial zoom level. |
+| `viewMode` | `'2D' \| '3D'` | `'2D'` | Map rendering mode. |
+| `theme` | `string \| undefined` | – | Theme identifier registered with AMap. |
+| `pitch` | `number \| undefined` | – | Initial pitch angle. |
+| `rotation` | `number \| undefined` | – | Initial rotation angle. |
+| `mapStyle` | `string \| undefined` | – | Custom style ID. |
+| `plugins` | `string[]` | `[]` | Additional JSAPI plugins to load. |
+| `loaderOptions` | `Partial<LoaderOptions>` | `{}` | Overrides passed to the shared loader (e.g. custom version). |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.Map` | Emitted once the map instance is available. |
+| `moveend` | `any` | Fires when map movement ends. |
+| `click` | `any` | Map click events. |
+| `complete` | `any` | Fired after all resources are loaded. |
+| `error` | `any` | Emitted if the underlying JSAPI reports an error. |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { AmapMap, AmapMarker } from '@amap-vue/core'
+
+const center = [116.397, 39.908]
+</script>
+
+<template>
+  <AmapMap :center="center" :zoom="11" style="height: 320px">
+    <AmapMarker :position="center" />
+  </AmapMap>
+</template>
+```
+
+<ClientOnly>
+  <BasicMapDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import BasicMapDemo from '../examples/BasicMapDemo.vue'
+</script>
+
+### StackBlitz
+
+[Open in StackBlitz](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/marker.md
+++ b/docs/components/marker.md
@@ -1,0 +1,36 @@
+# `<AmapMarker>`
+
+`<AmapMarker>` renders a standard JSAPI marker and automatically registers itself with the nearest `<AmapMap>`.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `position` | `LngLatLike` | Marker coordinates. |
+| `icon` | `string \| AMap.Icon` | Custom icon definition. |
+| `label` | `string \| AMap.MarkerLabelOptions` | Optional label displayed next to the marker. |
+| `draggable` | `boolean` | Enables drag interactions. |
+| `zIndex` | `number` | Z-index ordering. |
+| `extData` | `any` | Arbitrary data stored on the marker. |
+| `offset` | `AMap.Pixel \| [number, number]` | Pixel offset relative to the anchor point. |
+| `visible` | `boolean` | Controls marker visibility. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.Marker` | Fired when the marker is created. |
+| `click` | `any` | Marker click events. |
+| `dragend` | `any` | Fired after a drag finishes. |
+| `mouseover` | `any` | Hover enter events. |
+| `mouseout` | `any` | Hover leave events. |
+
+## Usage
+
+```vue
+<AmapMap :center="[116.397, 39.908]" :zoom="11" style="height: 320px">
+  <AmapMarker :position="[116.397, 39.908]" @click="handleClick" />
+</AmapMap>
+```
+
+Markers support arbitrary slot content inside `<AmapInfoWindow>` instances for rich popups.

--- a/docs/components/polygon.md
+++ b/docs/components/polygon.md
@@ -1,0 +1,35 @@
+# `<AmapPolygon>`
+
+Render filled polygons with optional holes. Accepts both single-ring and multi-ring paths.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `path` | `LngLatLike[] \| LngLatLike[][]` | Polygon coordinates. |
+| `options` | `Partial<AMap.PolygonOptions>` | Extra JSAPI options (stroke color, fill opacity, etc.). |
+| `visible` | `boolean` | Toggles visibility. |
+| `extData` | `any` | Arbitrary metadata. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.Polygon` | Fired after creation. |
+| `click` | `any` | Click events. |
+| `mouseover` | `any` | Pointer enter events. |
+| `mouseout` | `any` | Pointer leave events. |
+
+## Usage
+
+```vue
+<AmapPolygon
+  :path="[
+    [116.39, 39.90],
+    [116.42, 39.90],
+    [116.42, 39.92],
+    [116.39, 39.92]
+  ]"
+  :options="{ fillColor: 'rgba(75,139,255,0.25)', strokeColor: '#4b8bff' }"
+/>
+```

--- a/docs/components/polyline.md
+++ b/docs/components/polyline.md
@@ -1,0 +1,34 @@
+# `<AmapPolyline>`
+
+Draw polylines representing paths or routes. The component consumes the map context and updates reactively as props change.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `path` | `LngLatLike[]` | Ordered list of coordinates. |
+| `options` | `Partial<AMap.PolylineOptions>` | Additional JSAPI options. |
+| `visible` | `boolean` | Toggles visibility. |
+| `extData` | `any` | Custom metadata. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.Polyline` | Fired after creation. |
+| `click` | `any` | Click events along the line. |
+| `mouseover` | `any` | Pointer enter events. |
+| `mouseout` | `any` | Pointer leave events. |
+
+## Usage
+
+```vue
+<AmapPolyline
+  :path="[
+    [116.397, 39.908],
+    [116.427, 39.903],
+    [116.45, 39.92]
+  ]"
+  :options="{ strokeColor: '#4b8bff', strokeWeight: 4 }"
+/>
+```

--- a/docs/examples/BasicMapDemo.vue
+++ b/docs/examples/BasicMapDemo.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to see the live demo.
+    </div>
+    <div v-else class="amap-demo__map">
+      <AmapMap :center="center" :zoom="zoom">
+        <AmapMarker :position="center" />
+      </AmapMap>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { loader } from '@amap-vue/shared'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center = [116.397, 39.908]
+const zoom = 11
+const hasKey = computed(() => Boolean(key))
+</script>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,22 @@
+# FAQ & Troubleshooting
+
+## Why is the map blank?
+
+Ensure that the container element hosting `<AmapMap>` has an explicit height. Without a height the JSAPI will render an empty container.
+
+## I see an error about missing API key
+
+Call `loader.config({ key: 'YOUR_KEY' })` before rendering maps. The loader throws in development when no key is provided to avoid silent failures.
+
+## How do I run the examples?
+
+```bash
+pnpm install
+pnpm --filter examples/basic dev
+```
+
+Set `VITE_AMAP_KEY` in a `.env.local` file to use your own key.
+
+## How do I use the components in SSR?
+
+All composables guard against `window` access during setup. Only instantiate maps inside `onMounted`/`ready` callbacks on the client.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,79 @@
+# Getting Started
+
+AMap Vue Kit provides Vue 3 components and composables on top of the [AMap JSAPI 2.x](https://lbs.amap.com/api/javascript-api/summary). This guide walks you through installing the packages, configuring your API key, and rendering your first map.
+
+## Installation
+
+```bash
+pnpm add @amap-vue/core @amap-vue/hooks @amap-vue/shared vue
+```
+
+If you are using `npm` or `yarn`, substitute the install command accordingly.
+
+## Configure the loader
+
+Before creating any maps, configure the shared loader with your [AMap Web JSAPI key](https://lbs.amap.com/api/javascript-api/guide/create-project/get-key):
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+import App from './App.vue'
+import { loader } from '@amap-vue/shared'
+
+loader.config({
+  key: import.meta.env.VITE_AMAP_KEY,
+  version: '2.0'
+})
+
+createApp(App).mount('#app')
+```
+
+The loader ensures that the JSAPI script is injected only once, even when multiple maps are rendered across your application.
+
+## Render a map
+
+```vue
+<script setup lang="ts">
+import { AmapMap, AmapMarker } from '@amap-vue/core'
+
+const center = [116.397, 39.908]
+</script>
+
+<template>
+  <AmapMap :center="center" :zoom="11" style="height: 320px">
+    <AmapMarker :position="center" />
+  </AmapMap>
+</template>
+```
+
+The `<AmapMap>` component accepts all standard JSAPI map options and emits native AMap events (`ready`, `moveend`, `click`, `complete`, and `error`). Child overlays such as `<AmapMarker>` automatically register with the nearest map instance.
+
+## Use composables
+
+Prefer the Composition API? The `@amap-vue/hooks` package exposes the same functionality through composables:
+
+```ts
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useMap, useMarker } from '@amap-vue/hooks'
+
+const mapContainer = ref<HTMLDivElement | null>(null)
+const { map, ready } = useMap(() => ({
+  container: mapContainer,
+  center: [116.397, 39.908],
+  zoom: 11
+}))
+
+ready(() => {
+  useMarker(() => map.value, {
+    position: [116.397, 39.908]
+  })
+})
+</script>
+
+<template>
+  <div ref="mapContainer" style="height: 320px" />
+</template>
+```
+
+With the basics in place you are ready to explore the component and composable documentation, advanced guides, and performance tips.

--- a/docs/hooks/use-map.md
+++ b/docs/hooks/use-map.md
@@ -1,0 +1,30 @@
+# `useMap`
+
+`useMap` is a composition API wrapper around the map lifecycle. It lazily loads the JSAPI, instantiates the map, and exposes imperative helpers.
+
+```ts
+const { map, ready, setCenter, setZoom, on, off, destroy } = useMap(() => ({
+  container: containerRef,
+  center: [116.397, 39.908],
+  zoom: 11,
+  plugins: ['AMap.ToolBar']
+}))
+```
+
+## Return value
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `map` | `ShallowRef<AMap.Map \| null>` | Reactive reference to the map instance. |
+| `ready` | `(callback: (map: AMap.Map) => void) => void` | Registers a callback for when the map is available. |
+| `setCenter` | `(center?: LngLatLike) => void` | Updates the center. |
+| `setZoom` | `(zoom?: number) => void` | Updates the zoom level. |
+| `setPitch` | `(pitch?: number) => void` | Updates the pitch. |
+| `setRotation` | `(rotation?: number) => void` | Updates the rotation. |
+| `setMapStyle` | `(style?: string) => void` | Updates the map style. |
+| `setTheme` | `(theme?: string) => void` | Applies a registered theme. |
+| `setViewMode` | `(mode?: AMap.MapViewMode) => void` | Switch between 2D and 3D rendering. |
+| `on` / `off` | `(event: string, handler: (event: any) => void)` | Subscribe to JSAPI events. |
+| `destroy` | `() => void` | Dispose the map and detach listeners. |
+
+Because the loader is shared, calling `useMap` in multiple components will reuse the same script injection and plugin configuration.

--- a/docs/hooks/use-marker.md
+++ b/docs/hooks/use-marker.md
@@ -1,0 +1,27 @@
+# `useMarker`
+
+Create and manage JSAPI markers imperatively.
+
+```ts
+const markerApi = useMarker(() => map.value, () => ({
+  position: [116.397, 39.908],
+  label: 'AMap HQ',
+  draggable: true
+}))
+
+markerApi.on('click', (event) => {
+  console.log('marker clicked', event)
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `marker` | `ShallowRef<AMap.Marker \| null>` referencing the marker instance. |
+| `setPosition`, `setIcon`, `setLabel`, `setExtData`, `setDraggable`, `setZIndex`, `setOffset` | Imperative setters mirroring JSAPI methods. |
+| `show` / `hide` | Toggle marker visibility. |
+| `on` / `off` | Subscribe to marker events. |
+| `destroy` | Remove the marker from the map. |
+
+When the map reference becomes `null` (e.g. during unmount) the marker is automatically removed and destroyed.

--- a/docs/hooks/use-overlay.md
+++ b/docs/hooks/use-overlay.md
@@ -1,0 +1,23 @@
+# `useOverlay`
+
+`useOverlay` is a low-level helper for building overlay composables. It is used internally by the polygon, polyline, and circle components but can be used to wrap any overlay that exposes `setMap`.
+
+```ts
+const { overlay, destroy } = useOverlay(
+  () => map.value,
+  () => ({ path, strokeColor: '#4b8bff' }),
+  ({ AMap, map, options }) => {
+    const polyline = new AMap.Polyline({
+      ...options,
+      map,
+      path: options.path
+    })
+    return polyline
+  },
+  (polyline, options) => {
+    polyline.setOptions(options)
+  }
+)
+```
+
+`useOverlay` handles deferred instantiation until both the map and JSAPI are ready, automatically reattaches listeners, and cleans up on unmount.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+---
+layout: home
+hero:
+  name: AMap Vue Kit
+  text: Vue 3 wrappers for the AMap JSAPI 2.x
+  tagline: Build interactive maps with declarative components and type-safe composables.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/your-org/amap-vue-kit
+features:
+  - title: Vue-first experience
+    details: Designed around `<script setup>` SFCs, Composition API, and first-class TypeScript support.
+  - title: Powerful composables
+    details: Fine-grained control via composables such as `useMap`, `useMarker`, and high-performance helpers.
+  - title: Production ready
+    details: Tree-shakeable ESM build, strict linting, tested components, and VitePress documentation with live demos.
+---

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@amap-vue/docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "serve": "vitepress serve"
+  },
+  "dependencies": {
+    "@amap-vue/core": "workspace:*",
+    "@amap-vue/hooks": "workspace:*",
+    "@amap-vue/shared": "workspace:*",
+    "vitepress": "^1.1.0",
+    "vue": "^3.4.15"
+  }
+}

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,5 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="24" fill="#1F2937" />
+  <path d="M36 78L60 30L84 78H36Z" fill="#4B8BFF" />
+  <circle cx="60" cy="66" r="10" fill="#FFFFFF" />
+</svg>

--- a/docs/recipes/heatmap.md
+++ b/docs/recipes/heatmap.md
@@ -1,0 +1,24 @@
+# Heatmap
+
+Heatmaps provide an at-a-glance view of density. Load the `Heatmap` plugin via the shared loader.
+
+```ts
+ready((map) => {
+  map.plugin(['AMap.Heatmap'], () => {
+    const heatmap = new AMap.Heatmap(map, {
+      radius: 25,
+      opacity: [0, 0.8]
+    })
+    heatmap.setDataSet({
+      data: points.map((point) => ({
+        lng: point[0],
+        lat: point[1],
+        count: point[2]
+      })),
+      max: 10
+    })
+  })
+})
+```
+
+Wrap the heatmap instance in a composable to react to prop changes if you plan to update the dataset frequently.

--- a/docs/recipes/marker-clusters.md
+++ b/docs/recipes/marker-clusters.md
@@ -1,0 +1,19 @@
+# Marker Clusters
+
+AMap exposes `AMap.MarkerClusterer` to cluster dense marker sets.
+
+```ts
+ready((map) => {
+  map.plugin(['AMap.MarkerClusterer'], () => {
+    const cluster = new AMap.MarkerClusterer(map, markers, {
+      gridSize: 80,
+      maxZoom: 16
+    })
+    cluster.on('click', (event) => {
+      console.log('Cluster clicked', event)
+    })
+  })
+})
+```
+
+Use Vue refs to store the cluster instance and call `setMarkers` or `addMarkers` when your reactive data changes.

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "types": [
+      "vitepress/client",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.vue",
+    "**/*.md"
+  ]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import antfu from '@antfu/eslint-config'
+
+export default antfu({
+  ignores: [
+    'dist',
+    'packages/*/dist',
+    'docs/.vitepress/cache',
+    'docs/.vitepress/dist',
+    'examples/*/dist'
+  ],
+  vue: true,
+  typescript: true
+})

--- a/examples/basic/env.d.ts
+++ b/examples/basic/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_AMAP_KEY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AMap Vue Kit Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "amap-vue-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@amap-vue/core": "workspace:*",
+    "@amap-vue/hooks": "workspace:*",
+    "@amap-vue/shared": "workspace:*",
+    "vue": "^3.4.15"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.3",
+    "vite": "^5.1.4"
+  }
+}

--- a/examples/basic/src/App.vue
+++ b/examples/basic/src/App.vue
@@ -1,0 +1,71 @@
+<template>
+  <main class="app">
+    <h1>AMap Vue Kit Example</h1>
+    <p>Interact with the map to explore the declarative API.</p>
+    <div class="map-shell">
+      <div v-if="!hasKey" class="map-placeholder">
+        Set <code>VITE_AMAP_KEY</code> in `.env.local` to load the live JSAPI map.
+      </div>
+      <AmapMap v-else :center="center" :zoom="zoom" class="map">
+        <AmapMarker :position="center" @click="toggleInfo" />
+        <AmapInfoWindow :position="center" :is-open="infoOpen">
+          <div class="info">
+            <h4>Welcome!</h4>
+            <p>The marker toggles this info window.</p>
+          </div>
+        </AmapInfoWindow>
+      </AmapMap>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const center = ref<[number, number]>([116.397, 39.908])
+const zoom = ref(11)
+const infoOpen = ref(true)
+const hasKey = computed(() => Boolean(import.meta.env.VITE_AMAP_KEY))
+
+function toggleInfo() {
+  infoOpen.value = !infoOpen.value
+}
+</script>
+
+<style scoped>
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.map-shell {
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  overflow: hidden;
+  min-height: 360px;
+}
+
+.map {
+  height: 360px;
+  width: 100%;
+}
+
+.map-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 360px;
+  color: #475569;
+  background: #f8fafc;
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.info {
+  min-width: 180px;
+}
+</style>

--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import Core from '@amap-vue/core'
+import { loader } from '@amap-vue/shared'
+
+const key = import.meta.env.VITE_AMAP_KEY
+if (key)
+  loader.config({ key })
+
+createApp(App).use(Core).mount('#app')

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*", "env.d.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/hooks" },
+    { "path": "../../packages/shared" }
+  ]
+}

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "amap-vue-kit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "build": "pnpm -r --filter ./packages/* run build",
+    "build:all": "pnpm run build && pnpm --filter docs run build && pnpm --filter examples/basic run build",
+    "dev:docs": "pnpm --filter docs run dev",
+    "dev:example": "pnpm --filter examples/basic run dev",
+    "lint": "eslint .",
+    "test": "vitest",
+    "typecheck": "vue-tsc --build --force",
+    "changeset": "changeset",
+    "release": "changeset publish"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "^2.6.3",
+    "@changesets/cli": "^2.27.1",
+    "@types/amap-js-api": "^1.4.11",
+    "@types/node": "^20.11.0",
+    "@vitejs/plugin-vue": "^5.0.3",
+    "@vue/test-utils": "^2.4.3",
+    "eslint": "^8.57.0",
+    "jsdom": "^23.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4",
+    "vite-plugin-dts": "^3.7.3",
+    "vitest": "^1.3.1",
+    "vue": "^3.4.15",
+    "vue-tsc": "^1.8.27"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@amap-vue/core",
+  "version": "0.0.0",
+  "type": "module",
+  "private": false,
+  "files": [
+    "dist"
+  ],
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "clean": "rm -rf dist",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  },
+  "dependencies": {
+    "@amap-vue/hooks": "workspace:*",
+    "@amap-vue/shared": "workspace:*"
+  }
+}

--- a/packages/core/src/components/AmapCircle.vue
+++ b/packages/core/src/components/AmapCircle.vue
@@ -1,0 +1,106 @@
+<template />
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, watch } from 'vue'
+import type { PropType } from 'vue'
+import { useOverlay } from '@amap-vue/hooks'
+import { amapMapInjectionKey, type LngLatLike, type MapInjectionContext, loader, toLngLat, warn } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapCircle'
+})
+
+const props = defineProps({
+  center: {
+    type: [Array, Object] as PropType<LngLatLike>,
+    required: true
+  },
+  radius: {
+    type: Number,
+    required: true
+  },
+  options: {
+    type: Object as PropType<Partial<AMap.CircleOptions>>,
+    default: () => ({})
+  },
+  visible: {
+    type: Boolean,
+    default: true
+  },
+  extData: null as any
+})
+
+const emit = defineEmits<{
+  ready: [circle: AMap.Circle]
+  click: [event: any]
+  mouseover: [event: any]
+  mouseout: [event: any]
+}>()
+
+const context = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!context)
+  warn('<AmapCircle> must be used inside <AmapMap>.')
+
+const overlayOptions = computed(() => ({
+  center: props.center,
+  radius: props.radius,
+  visible: props.visible,
+  extData: props.extData,
+  ...props.options
+}))
+
+const overlayApi = context
+  ? useOverlay(() => context.map.value, overlayOptions, ({ AMap, map, options }) => {
+      const { center, radius, visible, map: _ignoredMap, ...rest } = options as any
+      const circle = new AMap.Circle({
+        ...rest,
+        center: center ? toLngLat(AMap, center) ?? center : undefined,
+        radius
+      })
+      circle.setMap(map)
+      if (visible === false)
+        circle.hide()
+      return circle
+    }, (circle, options) => {
+      const { center, radius, visible, map: _ignored, ...rest } = options as any
+      circle.setOptions(rest)
+      if (center) {
+        const AMapInstance = loader.get()
+        circle.setCenter((AMapInstance ? toLngLat(AMapInstance, center) ?? center : center) as any)
+      }
+      if (typeof radius === 'number')
+        circle.setRadius(radius)
+      if (visible == null)
+        return
+      if (visible)
+        circle.show()
+      else
+        circle.hide()
+    })
+  : null
+
+const eventBindings: Array<{ event: string; handler: (event: any) => void }> = [
+  { event: 'click', handler: event => emit('click', event) },
+  { event: 'mouseover', handler: event => emit('mouseover', event) },
+  { event: 'mouseout', handler: event => emit('mouseout', event) }
+]
+
+if (overlayApi) {
+  watch(overlayApi.overlay, (value) => {
+    if (value)
+      emit('ready', value)
+  })
+}
+
+eventBindings.forEach(({ event, handler }) => overlayApi?.on(event, handler))
+
+onBeforeUnmount(() => {
+  eventBindings.forEach(({ event, handler }) => overlayApi?.off(event, handler))
+  overlayApi?.destroy()
+})
+
+defineExpose({
+  circle: overlayApi?.overlay
+})
+</script>

--- a/packages/core/src/components/AmapInfoWindow.vue
+++ b/packages/core/src/components/AmapInfoWindow.vue
@@ -1,0 +1,126 @@
+<template>
+  <div ref="contentRef" class="amap-vue-infowindow-content">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { PropType } from 'vue'
+import { amapMapInjectionKey, type LngLatLike, type MapInjectionContext, toLngLat, toPixel, loader, warn } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapInfoWindow'
+})
+
+const props = defineProps({
+  position: [Array, Object] as PropType<LngLatLike | undefined>,
+  isOpen: {
+    type: Boolean,
+    default: false
+  },
+  offset: [Array, Object] as PropType<AMap.Pixel | [number, number]>
+})
+
+const emit = defineEmits<{
+  ready: [infoWindow: AMap.InfoWindow]
+}>()
+
+const context = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!context)
+  warn('<AmapInfoWindow> must be used inside <AmapMap>.')
+
+const contentRef = shallowRef<HTMLDivElement | null>(null)
+const infoWindow = shallowRef<AMap.InfoWindow | null>(null)
+const currentMap = shallowRef<AMap.Map | null>(null)
+let pendingOpen = props.isOpen
+
+context?.ready((map) => {
+  currentMap.value = map
+  createInfoWindow()
+})
+
+watch(contentRef, (el) => {
+  if (infoWindow.value && el)
+    infoWindow.value.setContent(el)
+})
+
+watch([contentRef, currentMap], () => {
+  if (currentMap.value && contentRef.value)
+    createInfoWindow()
+})
+
+watch(() => props.offset, (offset) => {
+  if (!infoWindow.value)
+    return
+  const AMap = loader.get()
+  if (AMap && offset)
+    infoWindow.value.setOffset(toPixel(AMap, offset) as any)
+}, { deep: true })
+
+watch(() => props.position, (position) => {
+  if (!infoWindow.value || !position)
+    return
+  const AMap = loader.get()
+  const lnglat = AMap ? toLngLat(AMap, position) : position
+  if (typeof infoWindow.value.setPosition === 'function')
+    infoWindow.value.setPosition(lnglat as any)
+  if (props.isOpen)
+    openWindow()
+}, { deep: true })
+
+watch(() => props.isOpen, (open) => {
+  pendingOpen = open
+  if (!infoWindow.value)
+    return
+  if (open)
+    openWindow()
+  else
+    infoWindow.value.close()
+}, { immediate: true })
+
+async function createInfoWindow() {
+  if (infoWindow.value || !contentRef.value || !currentMap.value)
+    return
+
+  try {
+    const AMap = await loader.load()
+    const instance = new AMap.InfoWindow({
+      content: contentRef.value,
+      offset: props.offset ? toPixel(AMap, props.offset) : undefined
+    })
+    infoWindow.value = instance
+    emit('ready', instance)
+    if (pendingOpen)
+      openWindow()
+  }
+  catch (error) {
+    warn(error instanceof Error ? error.message : String(error))
+  }
+}
+
+function openWindow() {
+  if (!infoWindow.value || !currentMap.value || !props.position)
+    return
+  const AMap = loader.get()
+  const lnglat = AMap ? toLngLat(AMap, props.position) : props.position
+  infoWindow.value.open(currentMap.value, lnglat as any)
+}
+
+onBeforeUnmount(() => {
+  infoWindow.value?.close()
+})
+
+defineExpose({
+  infoWindow
+})
+</script>
+
+<style scoped>
+.amap-vue-infowindow-content {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
+</style>

--- a/packages/core/src/components/AmapMap.vue
+++ b/packages/core/src/components/AmapMap.vue
@@ -1,0 +1,97 @@
+<template>
+  <div ref="containerRef" class="amap-vue-map">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, provide, shallowRef } from 'vue'
+import type { PropType } from 'vue'
+import { useMap } from '@amap-vue/hooks'
+import { amapMapInjectionKey, type LoaderOptions, type LngLatLike, type MapInjectionContext } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapMap'
+})
+
+const props = defineProps({
+  center: {
+    type: [Array, Object] as PropType<LngLatLike | undefined>,
+    default: undefined
+  },
+  zoom: Number,
+  viewMode: String as PropType<AMap.MapViewMode>,
+  theme: String,
+  pitch: Number,
+  rotation: Number,
+  mapStyle: String,
+  plugins: {
+    type: Array as PropType<string[]>,
+    default: () => []
+  },
+  loaderOptions: {
+    type: Object as PropType<Partial<LoaderOptions>>,
+    default: () => ({})
+  }
+})
+
+const emit = defineEmits<{
+  ready: [map: AMap.Map]
+  moveend: [event: any]
+  click: [event: any]
+  complete: [event: any]
+  error: [event: any]
+}>()
+
+const containerRef = shallowRef<HTMLDivElement | null>(null)
+
+const mapOptions = computed(() => ({
+  center: props.center,
+  zoom: props.zoom,
+  viewMode: props.viewMode,
+  theme: props.theme,
+  pitch: props.pitch,
+  rotation: props.rotation,
+  mapStyle: props.mapStyle,
+  plugins: props.plugins,
+  loaderOptions: props.loaderOptions,
+  container: containerRef.value
+}))
+
+const { map, ready, on, off, destroy } = useMap(mapOptions, containerRef)
+
+const eventBindings: Array<{ event: string; handler: (event: any) => void }> = [
+  { event: 'moveend', handler: event => emit('moveend', event) },
+  { event: 'click', handler: event => emit('click', event) },
+  { event: 'complete', handler: event => emit('complete', event) },
+  { event: 'error', handler: event => emit('error', event) }
+]
+
+eventBindings.forEach(({ event, handler }) => on(event, handler))
+
+ready((instance) => {
+  emit('ready', instance)
+})
+
+provide<MapInjectionContext>(amapMapInjectionKey, {
+  map,
+  ready
+})
+
+defineExpose({
+  map
+})
+
+onBeforeUnmount(() => {
+  eventBindings.forEach(({ event, handler }) => off(event, handler))
+  destroy()
+})
+</script>
+
+<style scoped>
+.amap-vue-map {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+</style>

--- a/packages/core/src/components/AmapMarker.vue
+++ b/packages/core/src/components/AmapMarker.vue
@@ -1,0 +1,84 @@
+<template />
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, shallowRef, watch } from 'vue'
+import type { PropType } from 'vue'
+import { useMarker } from '@amap-vue/hooks'
+import { amapMapInjectionKey, type LngLatLike, type MapInjectionContext, warn } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapMarker'
+})
+
+const props = defineProps({
+  position: {
+    type: [Array, Object] as PropType<LngLatLike>,
+    required: true
+  },
+  icon: [String, Object] as PropType<string | AMap.Icon>,
+  label: [String, Object] as PropType<string | AMap.MarkerLabelOptions>,
+  draggable: Boolean,
+  zIndex: Number,
+  extData: null as any,
+  offset: [Array, Object] as PropType<AMap.Pixel | [number, number]>,
+  visible: {
+    type: Boolean,
+    default: true
+  }
+})
+
+const emit = defineEmits<{
+  ready: [marker: AMap.Marker]
+  click: [event: any]
+  dragend: [event: any]
+  mouseover: [event: any]
+  mouseout: [event: any]
+}>()
+
+const context = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!context)
+  warn('<AmapMarker> must be used inside <AmapMap>.')
+
+const options = computed(() => ({
+  position: props.position,
+  icon: props.icon,
+  label: props.label,
+  draggable: props.draggable,
+  zIndex: props.zIndex,
+  extData: props.extData,
+  offset: props.offset,
+  visible: props.visible
+}))
+
+const markerApi = context ? useMarker(() => context.map.value, options) : null
+const marker = markerApi?.marker ?? shallowRef<AMap.Marker | null>(null)
+
+const eventBindings: Array<{ event: string; handler: (event: any) => void }> = [
+  { event: 'click', handler: event => emit('click', event) },
+  { event: 'dragend', handler: event => emit('dragend', event) },
+  { event: 'mouseover', handler: event => emit('mouseover', event) },
+  { event: 'mouseout', handler: event => emit('mouseout', event) }
+]
+
+if (markerApi)
+  eventBindings.forEach(({ event, handler }) => markerApi.on(event, handler))
+
+let readyEmitted = false
+
+watch(marker, (value) => {
+  if (value && !readyEmitted) {
+    readyEmitted = true
+    emit('ready', value)
+  }
+})
+
+onBeforeUnmount(() => {
+  eventBindings.forEach(({ event, handler }) => markerApi?.off(event, handler))
+  markerApi?.destroy()
+})
+
+defineExpose({
+  marker
+})
+</script>

--- a/packages/core/src/components/AmapPolygon.vue
+++ b/packages/core/src/components/AmapPolygon.vue
@@ -1,0 +1,117 @@
+<template />
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, watch } from 'vue'
+import type { PropType } from 'vue'
+import { useOverlay } from '@amap-vue/hooks'
+import { amapMapInjectionKey, type LngLatLike, type MapInjectionContext, loader, toLngLat, warn } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapPolygon'
+})
+
+export type PolygonPath = LngLatLike[] | LngLatLike[][]
+
+const props = defineProps({
+  path: {
+    type: [Array] as PropType<PolygonPath>,
+    required: true
+  },
+  options: {
+    type: Object as PropType<Partial<AMap.PolygonOptions>>,
+    default: () => ({})
+  },
+  visible: {
+    type: Boolean,
+    default: true
+  },
+  extData: null as any
+})
+
+const emit = defineEmits<{
+  ready: [polygon: AMap.Polygon]
+  click: [event: any]
+  mouseover: [event: any]
+  mouseout: [event: any]
+}>()
+
+const context = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!context)
+  warn('<AmapPolygon> must be used inside <AmapMap>.')
+
+const overlayOptions = computed(() => ({
+  path: props.path,
+  visible: props.visible,
+  extData: props.extData,
+  ...props.options
+}))
+
+function normalizePath(AMapInstance: typeof AMap | undefined, path: PolygonPath): any {
+  if (!Array.isArray(path))
+    return []
+
+  const convertPoint = (point: LngLatLike) => AMapInstance ? toLngLat(AMapInstance, point) ?? point : point
+
+  if (!path.length)
+    return []
+
+  const first = path[0] as any
+  if (Array.isArray(first) && typeof first[0] !== 'number') {
+    return (path as LngLatLike[][]).map(segment => segment.map(point => convertPoint(point)))
+  }
+
+  return (path as LngLatLike[]).map(point => convertPoint(point))
+}
+
+const overlayApi = context
+  ? useOverlay(() => context.map.value, overlayOptions, ({ AMap, map, options }) => {
+      const { path, visible, map: _ignoredMap, ...rest } = options as any
+      const polygon = new AMap.Polygon({
+        ...rest,
+        path: normalizePath(AMap, path)
+      })
+      polygon.setMap(map)
+      if (visible === false)
+        polygon.hide()
+      return polygon
+    }, (polygon, options) => {
+      const { path, visible, map: _ignored, ...rest } = options as any
+      polygon.setOptions(rest)
+      if (path) {
+        const AMapInstance = loader.get()
+        polygon.setPath(normalizePath(AMapInstance, path) as any)
+      }
+      if (visible == null)
+        return
+      if (visible)
+        polygon.show()
+      else
+        polygon.hide()
+    })
+  : null
+
+const eventBindings: Array<{ event: string; handler: (event: any) => void }> = [
+  { event: 'click', handler: event => emit('click', event) },
+  { event: 'mouseover', handler: event => emit('mouseover', event) },
+  { event: 'mouseout', handler: event => emit('mouseout', event) }
+]
+
+if (overlayApi) {
+  watch(overlayApi.overlay, (value) => {
+    if (value)
+      emit('ready', value)
+  })
+}
+
+eventBindings.forEach(({ event, handler }) => overlayApi?.on(event, handler))
+
+onBeforeUnmount(() => {
+  eventBindings.forEach(({ event, handler }) => overlayApi?.off(event, handler))
+  overlayApi?.destroy()
+})
+
+defineExpose({
+  polygon: overlayApi?.overlay
+})
+</script>

--- a/packages/core/src/components/AmapPolyline.vue
+++ b/packages/core/src/components/AmapPolyline.vue
@@ -1,0 +1,106 @@
+<template />
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, watch } from 'vue'
+import type { PropType } from 'vue'
+import { useOverlay } from '@amap-vue/hooks'
+import { amapMapInjectionKey, type LngLatLike, type MapInjectionContext, loader, toLngLat, warn } from '@amap-vue/shared'
+
+defineOptions({
+  name: 'AmapPolyline'
+})
+
+export interface PolylineProps {
+  path: LngLatLike[]
+  options?: Partial<AMap.PolylineOptions>
+  visible?: boolean
+  extData?: any
+}
+
+const props = defineProps({
+  path: {
+    type: Array as PropType<LngLatLike[]>,
+    required: true
+  },
+  options: {
+    type: Object as PropType<Partial<AMap.PolylineOptions>>,
+    default: () => ({})
+  },
+  visible: {
+    type: Boolean,
+    default: true
+  },
+  extData: null as any
+})
+
+const emit = defineEmits<{
+  ready: [polyline: AMap.Polyline]
+  click: [event: any]
+  mouseover: [event: any]
+  mouseout: [event: any]
+}>()
+
+const context = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!context)
+  warn('<AmapPolyline> must be used inside <AmapMap>.')
+
+const overlayOptions = computed(() => ({
+  path: props.path,
+  visible: props.visible,
+  extData: props.extData,
+  ...props.options
+}))
+
+const overlayApi = context
+  ? useOverlay(() => context.map.value, overlayOptions, ({ AMap, map, options }) => {
+      const { path, visible, map: _ignoredMap, ...rest } = options as any
+      const polyline = new AMap.Polyline({
+        ...rest,
+        path: (path ?? []).map(item => toLngLat(AMap, item) ?? item)
+      })
+      polyline.setMap(map)
+      if (visible === false)
+        polyline.hide()
+      return polyline
+    }, (polyline, options) => {
+      const { path, visible, map: _ignored, ...rest } = options as any
+      polyline.setOptions(rest)
+      if (path) {
+        const AMapInstance = loader.get()
+        const resolvedPath = path.map((item: LngLatLike) => AMapInstance ? toLngLat(AMapInstance, item) ?? item : item)
+        polyline.setPath(resolvedPath as any)
+      }
+      if (visible == null)
+        return
+      if (visible)
+        polyline.show()
+      else
+        polyline.hide()
+    })
+  : null
+
+const eventBindings: Array<{ event: string; handler: (event: any) => void }> = [
+  { event: 'click', handler: event => emit('click', event) },
+  { event: 'mouseover', handler: event => emit('mouseover', event) },
+  { event: 'mouseout', handler: event => emit('mouseout', event) }
+]
+
+if (overlayApi) {
+  watch(overlayApi.overlay, (value) => {
+    if (value)
+      emit('ready', value)
+  })
+}
+
+eventBindings.forEach(({ event, handler }) => overlayApi?.on(event, handler))
+
+onBeforeUnmount(() => {
+  eventBindings.forEach(({ event, handler }) => overlayApi?.off(event, handler))
+  overlayApi?.destroy()
+})
+
+defineExpose({
+  polyline: overlayApi?.overlay
+})
+</script>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,30 @@
+import type { App } from 'vue'
+
+import AmapMap from './components/AmapMap.vue'
+import AmapMarker from './components/AmapMarker.vue'
+import AmapInfoWindow from './components/AmapInfoWindow.vue'
+import AmapPolyline from './components/AmapPolyline.vue'
+import AmapPolygon from './components/AmapPolygon.vue'
+import AmapCircle from './components/AmapCircle.vue'
+
+export { AmapMap, AmapMarker, AmapInfoWindow, AmapPolyline, AmapPolygon, AmapCircle }
+
+const components = [
+  AmapMap,
+  AmapMarker,
+  AmapInfoWindow,
+  AmapPolyline,
+  AmapPolygon,
+  AmapCircle
+]
+
+export function install(app: App) {
+  components.forEach((component) => {
+    if (component.name)
+      app.component(component.name, component)
+  })
+}
+
+export default {
+  install
+}

--- a/packages/core/tests/map.spec.ts
+++ b/packages/core/tests/map.spec.ts
@@ -1,0 +1,97 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AmapMap from '../src/components/AmapMap.vue'
+import AmapMarker from '../src/components/AmapMarker.vue'
+import AmapInfoWindow from '../src/components/AmapInfoWindow.vue'
+
+async function waitForMap() {
+  await flushPromises()
+  await flushPromises()
+}
+
+describe('AmapMap', () => {
+  it('creates map instance and reacts to prop changes', async () => {
+    const wrapper = mount(AmapMap, {
+      props: {
+        center: [120, 30],
+        zoom: 10,
+        pitch: 30
+      }
+    })
+
+    await waitForMap()
+
+    const readyEvents = wrapper.emitted('ready')
+    expect(readyEvents).toBeTruthy()
+    const map = (wrapper.vm as any).map.value
+    expect(map).toBeTruthy()
+    expect(map.options.center).toEqual([120, 30])
+
+    await wrapper.setProps({ zoom: 12 })
+    await waitForMap()
+    expect(map.options.zoom).toBe(12)
+
+    await wrapper.setProps({ center: [121, 31] })
+    await waitForMap()
+    expect(map.options.center).toEqual([121, 31])
+  })
+})
+
+describe('AmapMarker', () => {
+  it('syncs marker position and emits events', async () => {
+    const wrapper = mount({
+      components: { AmapMap, AmapMarker },
+      data: () => ({ position: [100, 20] as [number, number] }),
+      template: `
+        <AmapMap :center="[100, 20]" :zoom="12">
+          <AmapMarker :position="position" @click="onClick" />
+        </AmapMap>
+      `,
+      methods: {
+        onClick() {}
+      }
+    })
+
+    await waitForMap()
+
+    const markerComponent = wrapper.findComponent(AmapMarker)
+    const marker = (markerComponent.vm as any).marker.value
+    expect(marker).toBeTruthy()
+    expect(marker.options.position).toEqual([100, 20])
+
+    wrapper.vm.position = [101, 21]
+    await waitForMap()
+    expect(marker.options.position).toEqual([101, 21])
+
+    marker.emit('click', { type: 'click' })
+    await waitForMap()
+    expect(markerComponent.emitted('click')?.[0][0]).toEqual({ type: 'click' })
+  })
+})
+
+describe('AmapInfoWindow', () => {
+  it('opens and closes based on props', async () => {
+    const wrapper = mount({
+      components: { AmapMap, AmapInfoWindow },
+      data: () => ({ open: true }),
+      template: `
+        <AmapMap :center="[0, 0]" :zoom="12">
+          <AmapInfoWindow :position="[0, 0]" :is-open="open">
+            <span>Hello</span>
+          </AmapInfoWindow>
+        </AmapMap>
+      `
+    })
+
+    await waitForMap()
+
+    const infoWindowComponent = wrapper.findComponent(AmapInfoWindow)
+    const infoWindow = (infoWindowComponent.vm as any).infoWindow.value
+    expect(infoWindow?.opened).toBe(true)
+
+    wrapper.vm.open = false
+    await waitForMap()
+    expect(infoWindow?.opened).toBe(false)
+  })
+})

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "types": [
+      "node",
+      "vite/client"
+    ]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    dts({
+      entryRoot: 'src',
+      outputDir: 'dist',
+      insertTypesEntry: true
+    })
+  ],
+  build: {
+    target: 'esnext',
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'AmapVueCore',
+      fileName: () => 'index.js',
+      formats: ['es']
+    },
+    rollupOptions: {
+      external: ['vue', '@amap-vue/hooks', '@amap-vue/shared']
+    }
+  }
+})

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@amap-vue/hooks",
+  "version": "0.0.0",
+  "type": "module",
+  "private": false,
+  "files": [
+    "dist"
+  ],
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  },
+  "dependencies": {
+    "@amap-vue/shared": "workspace:*"
+  }
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,0 +1,4 @@
+export * from './useMap'
+export * from './useMarker'
+export * from './useOverlay'
+export * from './useMassMarkers'

--- a/packages/hooks/src/useMap.ts
+++ b/packages/hooks/src/useMap.ts
@@ -1,0 +1,263 @@
+import { computed, onBeforeUnmount, onMounted, shallowRef, toValue, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import type { LngLatLike, ReadyCallback, LoaderOptions } from '@amap-vue/shared'
+import { loader } from '@amap-vue/shared'
+import { isClient, toLngLat, warn } from '@amap-vue/shared'
+
+export interface UseMapOptions extends Partial<AMap.MapOptions> {
+  container?: MaybeRefOrGetter<HTMLElement | null | undefined> | string | HTMLElement
+  plugins?: string[]
+  loaderOptions?: Partial<LoaderOptions>
+}
+
+export interface UseMapReturn {
+  map: ShallowRef<AMap.Map | null>
+  ready: (callback: ReadyCallback) => void
+  setCenter: (center: LngLatLike | undefined) => void
+  setZoom: (zoom: number | undefined) => void
+  setPitch: (pitch: number | undefined) => void
+  setRotation: (rotation: number | undefined) => void
+  setMapStyle: (style: string | undefined) => void
+  setTheme: (theme: string | undefined) => void
+  setViewMode: (mode: AMap.MapViewMode | undefined) => void
+  on: (event: string, handler: (event: any) => void) => void
+  off: (event: string, handler: (event: any) => void) => void
+  destroy: () => void
+  setContainer: (element: HTMLElement | null) => void
+}
+
+type ContainerLike = MaybeRefOrGetter<HTMLElement | null | undefined> | string | HTMLElement
+
+function resolveContainer(source: ContainerLike | undefined): HTMLElement | null {
+  if (!isClient || !source)
+    return null
+
+  if (typeof source === 'string')
+    return document.querySelector<HTMLElement>(source) ?? document.getElementById(source) ?? null
+
+  if (source instanceof HTMLElement)
+    return source
+
+  const value = toValue(source)
+  return value ?? null
+}
+
+export function useMap(options: MaybeRefOrGetter<UseMapOptions>, container?: MaybeRefOrGetter<HTMLElement | null | undefined>): UseMapReturn {
+  const map = shallowRef<AMap.Map | null>(null)
+  const containerRef = shallowRef<HTMLElement | null>(null)
+  const readyCallbacks: ReadyCallback[] = []
+  const listeners = new Set<{ event: string; handler: (event: any) => void }>()
+  let creating = false
+
+  const optionsRef = computed<UseMapOptions>(() => ({
+    ...(toValue(options) as UseMapOptions | undefined ?? {})
+  }))
+
+  const containerSource = computed(() => {
+    const opts = optionsRef.value
+    const fromOptions = resolveContainer(opts.container)
+    if (fromOptions)
+      return fromOptions
+
+    return resolveContainer(container)
+  })
+
+  watch(containerSource, (value) => {
+    if (value)
+      containerRef.value = value
+  }, { immediate: true })
+
+  if (container) {
+    watch(() => toValue(container), (value) => {
+      if (value)
+        containerRef.value = value
+    })
+  }
+
+  function bindListeners(instance: AMap.Map) {
+    for (const listener of listeners)
+      (instance as any).on?.(listener.event, listener.handler)
+  }
+
+  function unbindListeners(instance: AMap.Map) {
+    for (const listener of listeners)
+      (instance as any).off?.(listener.event, listener.handler)
+  }
+
+  async function ensureMap() {
+    if (!isClient || creating || map.value || !containerRef.value)
+      return
+
+    creating = true
+    try {
+      const opts = optionsRef.value
+      const { container: _ignoredContainer, plugins, loaderOptions, ...mapOptions } = opts
+      const loadOptions: Partial<LoaderOptions> = {
+        ...(plugins ? { plugins } : {}),
+        ...loaderOptions
+      }
+
+      const AMap = await loader.load(loadOptions)
+      const instance = new AMap.Map(containerRef.value!, mapOptions)
+      map.value = instance
+      bindListeners(instance)
+      readyCallbacks.splice(0, readyCallbacks.length).forEach(cb => cb(instance))
+      applyInitialOptions(instance, opts)
+    }
+    catch (error) {
+      warn(error instanceof Error ? error.message : String(error))
+    }
+    finally {
+      creating = false
+    }
+  }
+
+  function applyInitialOptions(instance: AMap.Map, opts: UseMapOptions) {
+    setCenter(opts.center)
+    setZoom(opts.zoom)
+    setPitch(opts.pitch)
+    setRotation(opts.rotation)
+    setMapStyle(opts.mapStyle)
+    setTheme(opts.theme as string | undefined)
+    setViewMode(opts.viewMode)
+  }
+
+  watch(() => optionsRef.value.center, value => setCenter(value), { deep: true })
+  watch(() => optionsRef.value.zoom, value => setZoom(value))
+  watch(() => optionsRef.value.pitch, value => setPitch(value))
+  watch(() => optionsRef.value.rotation, value => setRotation(value))
+  watch(() => optionsRef.value.mapStyle, value => setMapStyle(value))
+  watch(() => optionsRef.value.theme as string | undefined, value => setTheme(value))
+  watch(() => optionsRef.value.viewMode, value => setViewMode(value as AMap.MapViewMode | undefined))
+
+  watch(containerRef, (value) => {
+    if (value)
+      ensureMap()
+  }, { immediate: true })
+
+  onMounted(() => {
+    if (containerRef.value)
+      ensureMap()
+  })
+
+  onBeforeUnmount(() => {
+    destroy()
+  })
+
+  function ready(callback: ReadyCallback) {
+    if (map.value)
+      callback(map.value)
+    else
+      readyCallbacks.push(callback)
+  }
+
+  function setCenter(center: LngLatLike | undefined) {
+    if (!center)
+      return
+    const instance = map.value
+    if (!instance)
+      return
+    const AMap = loader.get()
+    const value = AMap ? toLngLat(AMap, center) : center
+    instance.setCenter(value as any)
+  }
+
+  function setZoom(zoom: number | undefined) {
+    if (zoom == null)
+      return
+    const instance = map.value
+    instance?.setZoom(zoom)
+  }
+
+  function setPitch(pitch: number | undefined) {
+    if (pitch == null)
+      return
+    const instance = map.value
+    if (instance && typeof instance.setPitch === 'function')
+      instance.setPitch(pitch)
+  }
+
+  function setRotation(rotation: number | undefined) {
+    if (rotation == null)
+      return
+    const instance = map.value
+    if (instance && typeof instance.setRotation === 'function')
+      instance.setRotation(rotation)
+  }
+
+  function setMapStyle(style: string | undefined) {
+    if (!style)
+      return
+    const instance = map.value
+    if (instance && typeof instance.setMapStyle === 'function')
+      instance.setMapStyle(style)
+  }
+
+  function setTheme(theme: string | undefined) {
+    if (!theme)
+      return
+    const instance = map.value as any
+    if (instance?.setTheme)
+      instance.setTheme(theme)
+    else if (instance?.setMapStyle)
+      instance.setMapStyle(theme)
+  }
+
+  function setViewMode(mode: AMap.MapViewMode | undefined) {
+    if (!mode)
+      return
+    const instance = map.value as any
+    if (instance?.setStatus)
+      instance.setStatus({ viewMode: mode })
+  }
+
+  function on(event: string, handler: (event: any) => void) {
+    const record = { event, handler }
+    listeners.add(record)
+    if (map.value)
+      (map.value as any).on?.(event, handler)
+  }
+
+  function off(event: string, handler: (event: any) => void) {
+    for (const listener of Array.from(listeners)) {
+      if (listener.event === event && listener.handler === handler) {
+        if (map.value)
+          (map.value as any).off?.(event, handler)
+        listeners.delete(listener)
+      }
+    }
+  }
+
+  function destroy() {
+    const instance = map.value as any
+    if (instance) {
+      unbindListeners(instance)
+      if (typeof instance.destroy === 'function')
+        instance.destroy()
+      else
+        instance.setStatus?.({})
+    }
+    map.value = null
+  }
+
+  function setContainer(element: HTMLElement | null) {
+    if (element)
+      containerRef.value = element
+  }
+
+  return {
+    map,
+    ready,
+    setCenter,
+    setZoom,
+    setPitch,
+    setRotation,
+    setMapStyle,
+    setTheme,
+    setViewMode,
+    on,
+    off,
+    destroy,
+    setContainer
+  }
+}

--- a/packages/hooks/src/useMarker.ts
+++ b/packages/hooks/src/useMarker.ts
@@ -1,0 +1,201 @@
+import { computed, onBeforeUnmount, shallowRef, toValue, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import type { LngLatLike } from '@amap-vue/shared'
+import { loader, toLngLat, toPixel, warn } from '@amap-vue/shared'
+import { isClient } from '@amap-vue/shared'
+
+export interface UseMarkerOptions extends Partial<AMap.MarkerOptions> {
+  position?: LngLatLike
+  offset?: AMap.Pixel | [number, number]
+}
+
+export interface UseMarkerReturn {
+  marker: ShallowRef<AMap.Marker | null>
+  setPosition: (position: LngLatLike | undefined) => void
+  setIcon: (icon: AMap.Icon | string | undefined) => void
+  setLabel: (label: AMap.MarkerLabelOptions | string | undefined) => void
+  setExtData: (extData: any) => void
+  setDraggable: (draggable: boolean | undefined) => void
+  setZIndex: (zIndex: number | undefined) => void
+  setOffset: (offset: AMap.Pixel | [number, number] | undefined) => void
+  show: () => void
+  hide: () => void
+  on: (event: string, handler: (event: any) => void) => void
+  off: (event: string, handler: (event: any) => void) => void
+  destroy: () => void
+}
+
+export function useMarker(mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>, options: MaybeRefOrGetter<UseMarkerOptions> = {}): UseMarkerReturn {
+  const marker = shallowRef<AMap.Marker | null>(null)
+  const listeners = new Set<{ event: string; handler: (event: any) => void }>()
+  const optionsRef = computed<UseMarkerOptions>(() => ({
+    ...(toValue(options) as UseMarkerOptions | undefined ?? {})
+  }))
+
+  async function ensureMarker(mapInstance: AMap.Map | null | undefined) {
+    if (!isClient || marker.value || !mapInstance)
+      return
+
+    try {
+      const opts = optionsRef.value
+      const { position, offset, ...rest } = opts
+      const AMap = await loader.load()
+      const instance = new AMap.Marker({
+        ...rest,
+        map: mapInstance
+      })
+      marker.value = instance
+      bindListeners(instance)
+      if (position)
+        setPosition(position)
+      if (offset)
+        setOffset(offset)
+    }
+    catch (error) {
+      warn(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  function bindListeners(instance: AMap.Marker) {
+    for (const listener of listeners)
+      (instance as any).on?.(listener.event, listener.handler)
+  }
+
+  function unbindListeners(instance: AMap.Marker) {
+    for (const listener of listeners)
+      (instance as any).off?.(listener.event, listener.handler)
+  }
+
+  watch(() => toValue(mapRef), (mapInstance) => {
+    if (!mapInstance) {
+      marker.value?.setMap(null as any)
+      return
+    }
+
+    if (marker.value)
+      marker.value.setMap(mapInstance)
+    else
+      ensureMarker(mapInstance)
+  }, { immediate: true })
+
+  watch(() => optionsRef.value.position, value => setPosition(value), { deep: true })
+  watch(() => optionsRef.value.icon, value => setIcon(value as any))
+  watch(() => optionsRef.value.label, value => setLabel(value as any))
+  watch(() => optionsRef.value.draggable, value => setDraggable(value))
+  watch(() => optionsRef.value.zIndex, value => setZIndex(value))
+  watch(() => optionsRef.value.extData, value => setExtData(value))
+  watch(() => optionsRef.value.offset, value => setOffset(value as any), { deep: true })
+  watch(() => optionsRef.value.visible, (visible) => {
+    if (visible == null)
+      return
+    if (visible)
+      show()
+    else
+      hide()
+  })
+
+  onBeforeUnmount(() => {
+    destroy()
+  })
+
+  function setPosition(position: LngLatLike | undefined) {
+    if (!position)
+      return
+    const instance = marker.value
+    if (!instance)
+      return
+    const AMap = loader.get()
+    const value = AMap ? toLngLat(AMap, position) : position
+    instance.setPosition(value as any)
+  }
+
+  function setIcon(icon: AMap.Icon | string | undefined) {
+    if (!icon)
+      return
+    marker.value?.setIcon(icon as any)
+  }
+
+  function setLabel(label: AMap.MarkerLabelOptions | string | undefined) {
+    if (!label)
+      return
+    marker.value?.setLabel(label as any)
+  }
+
+  function setExtData(extData: any) {
+    marker.value?.setExtData(extData)
+  }
+
+  function setDraggable(draggable: boolean | undefined) {
+    if (draggable == null)
+      return
+    marker.value?.setDraggable(draggable)
+  }
+
+  function setZIndex(zIndex: number | undefined) {
+    if (zIndex == null)
+      return
+    marker.value?.setzIndex(zIndex)
+  }
+
+  function setOffset(offset: AMap.Pixel | [number, number] | undefined) {
+    if (!offset)
+      return
+    const instance = marker.value
+    if (!instance)
+      return
+    const AMap = loader.get()
+    const value = AMap ? toPixel(AMap, offset) : offset
+    instance.setOffset(value as any)
+  }
+
+  function show() {
+    marker.value?.show()
+  }
+
+  function hide() {
+    marker.value?.hide()
+  }
+
+  function on(event: string, handler: (event: any) => void) {
+    const record = { event, handler }
+    listeners.add(record)
+    if (marker.value)
+      (marker.value as any).on?.(event, handler)
+  }
+
+  function off(event: string, handler: (event: any) => void) {
+    for (const listener of Array.from(listeners)) {
+      if (listener.event === event && listener.handler === handler) {
+        if (marker.value)
+          (marker.value as any).off?.(event, handler)
+        listeners.delete(listener)
+      }
+    }
+  }
+
+  function destroy() {
+    const instance = marker.value as any
+    if (instance) {
+      unbindListeners(instance)
+      instance.setMap?.(null)
+      instance.destroy?.()
+    }
+    marker.value = null
+  }
+
+  return {
+    marker,
+    setPosition,
+    setIcon,
+    setLabel,
+    setExtData,
+    setDraggable,
+    setZIndex,
+    setOffset,
+    show,
+    hide,
+    on,
+    off,
+    destroy
+  }
+}

--- a/packages/hooks/src/useMassMarkers.ts
+++ b/packages/hooks/src/useMassMarkers.ts
@@ -1,0 +1,86 @@
+import { computed, shallowRef, toValue, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import { isClient, loader, warn } from '@amap-vue/shared'
+
+export interface UseMassMarkersOptions {
+  data: AMap.MassData[]
+  style?: AMap.MassMarkersStyleOptions | AMap.MassMarkersStyleOptions[]
+  options?: Partial<AMap.MassMarkersOptions>
+}
+
+export interface UseMassMarkersReturn {
+  mass: ShallowRef<AMap.MassMarks | null>
+  setData: (data: AMap.MassData[]) => void
+  setStyle: (style: AMap.MassMarkersStyleOptions | AMap.MassMarkersStyleOptions[]) => void
+  destroy: () => void
+}
+
+export function useMassMarkers(mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>, options: MaybeRefOrGetter<UseMassMarkersOptions>)
+  : UseMassMarkersReturn {
+  const mass = shallowRef<AMap.MassMarks | null>(null)
+  const optionsRef = computed<UseMassMarkersOptions>(() => ({
+    ...(toValue(options) as UseMassMarkersOptions | undefined ?? {})
+  }))
+
+  async function ensureMassMarkers(mapInstance: AMap.Map | null | undefined) {
+    if (!isClient || mass.value || !mapInstance)
+      return
+
+    try {
+      const { data, style, options: massOptions } = optionsRef.value
+      const AMap = await loader.load({ plugins: ['AMap.MassMarks'] })
+      const instance = new (AMap as any).MassMarks(data ?? [], {
+        ...(massOptions ?? {}),
+        map: mapInstance,
+        style
+      }) as AMap.MassMarks
+      mass.value = instance
+    }
+    catch (error) {
+      warn(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  watch(() => toValue(mapRef), (mapInstance) => {
+    if (!mapInstance) {
+      mass.value?.setMap(null)
+      return
+    }
+
+    if (mass.value)
+      mass.value.setMap(mapInstance)
+    else
+      ensureMassMarkers(mapInstance)
+  }, { immediate: true })
+
+  watch(() => optionsRef.value.data, data => setData(data ?? []), { deep: true })
+  watch(() => optionsRef.value.style, style => {
+    if (style)
+      setStyle(style)
+  }, { deep: true })
+
+  function setData(data: AMap.MassData[]) {
+    mass.value?.setData(data)
+  }
+
+  function setStyle(style: AMap.MassMarkersStyleOptions | AMap.MassMarkersStyleOptions[]) {
+    if (!mass.value)
+      return
+    if (Array.isArray(style))
+      mass.value.setStyle(style)
+    else
+      mass.value.setStyle(style)
+  }
+
+  function destroy() {
+    mass.value?.destroy?.()
+    mass.value = null
+  }
+
+  return {
+    mass,
+    setData,
+    setStyle,
+    destroy
+  }
+}

--- a/packages/hooks/src/useOverlay.ts
+++ b/packages/hooks/src/useOverlay.ts
@@ -1,0 +1,109 @@
+import { computed, onBeforeUnmount, shallowRef, toValue, watch } from 'vue'
+import type { MaybeRefOrGetter, ShallowRef } from 'vue'
+import { isClient, loader, warn } from '@amap-vue/shared'
+
+export interface OverlayLifecycle<TOverlay> {
+  overlay: ShallowRef<TOverlay | null>
+  destroy: () => void
+  on: (event: string, handler: (event: any) => void) => void
+  off: (event: string, handler: (event: any) => void) => void
+}
+
+export type OverlayFactory<TOverlay, TOptions> = (context: { AMap: typeof AMap; map: AMap.Map; options: TOptions }) => TOverlay
+export type OverlayUpdater<TOverlay, TOptions> = (overlay: TOverlay, options: TOptions) => void
+
+export function useOverlay<TOverlay extends { setMap(map: AMap.Map | null): void }, TOptions extends Record<string, any>>(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<TOptions>,
+  factory: OverlayFactory<TOverlay, TOptions>,
+  updater?: OverlayUpdater<TOverlay, TOptions>
+): OverlayLifecycle<TOverlay> {
+  const overlay = shallowRef<TOverlay | null>(null)
+  const listeners = new Set<{ event: string; handler: (event: any) => void }>()
+  const optionsRef = computed<TOptions>(() => ({
+    ...(toValue(options) as TOptions | undefined ?? {})
+  }) as TOptions)
+
+  async function ensureOverlay(mapInstance: AMap.Map | null | undefined) {
+    if (!isClient || overlay.value || !mapInstance)
+      return
+
+    try {
+      const AMap = await loader.load()
+      const instance = factory({ AMap, map: mapInstance, options: optionsRef.value })
+      overlay.value = instance
+      bindListeners(instance)
+      updater?.(instance, optionsRef.value)
+    }
+    catch (error) {
+      warn(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  function bindListeners(instance: TOverlay) {
+    for (const listener of listeners)
+      (instance as any).on?.(listener.event, listener.handler)
+  }
+
+  function unbindListeners(instance: TOverlay) {
+    for (const listener of listeners)
+      (instance as any).off?.(listener.event, listener.handler)
+  }
+
+  watch(() => toValue(mapRef), (mapInstance) => {
+    if (!mapInstance) {
+      overlay.value?.setMap(null)
+      return
+    }
+
+    if (overlay.value)
+      overlay.value.setMap(mapInstance)
+    else
+      ensureOverlay(mapInstance)
+  }, { immediate: true })
+
+  if (updater) {
+    watch(optionsRef, (value) => {
+      if (overlay.value)
+        updater(overlay.value, value)
+    }, { deep: true })
+  }
+
+  onBeforeUnmount(() => {
+    destroy()
+  })
+
+  function on(event: string, handler: (event: any) => void) {
+    const record = { event, handler }
+    listeners.add(record)
+    if (overlay.value)
+      (overlay.value as any).on?.(event, handler)
+  }
+
+  function off(event: string, handler: (event: any) => void) {
+    for (const listener of Array.from(listeners)) {
+      if (listener.event === event && listener.handler === handler) {
+        if (overlay.value)
+          (overlay.value as any).off?.(event, handler)
+        listeners.delete(listener)
+      }
+    }
+  }
+
+  function destroy() {
+    const instance = overlay.value as any
+    if (instance) {
+      unbindListeners(instance)
+      instance.setMap?.(null)
+      instance.destroy?.()
+    }
+    overlay.value = null
+  }
+
+  return {
+    overlay,
+    destroy,
+    on,
+    off
+  }
+}

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "tests", "**/*.test.ts"]
+}

--- a/packages/hooks/vite.config.ts
+++ b/packages/hooks/vite.config.ts
@@ -1,0 +1,24 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es'],
+      fileName: () => 'index.js'
+    },
+    rollupOptions: {
+      external: ['vue', '@amap-vue/shared']
+    }
+  },
+  plugins: [
+    dts({
+      entryRoot: 'src',
+      outputDir: 'dist',
+      insertTypesEntry: true
+    })
+  ]
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@amap-vue/shared",
+  "version": "0.0.0",
+  "type": "module",
+  "private": false,
+  "files": [
+    "dist"
+  ],
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,4 @@
+export * from './injection'
+export * from './loader'
+export * from './types'
+export * from './utils'

--- a/packages/shared/src/injection.ts
+++ b/packages/shared/src/injection.ts
@@ -1,0 +1,5 @@
+import type { MapInjectionContext } from './types'
+
+export const amapMapInjectionKey: unique symbol = Symbol('amap-map-context')
+
+export type { MapInjectionContext }

--- a/packages/shared/src/loader.ts
+++ b/packages/shared/src/loader.ts
@@ -1,0 +1,163 @@
+import { isClient, invariant, warn } from './utils'
+import type { LoaderOptions } from './types'
+
+const DEFAULT_VERSION = '2.0'
+const DEFAULT_LOCA_VERSION = '2.0.0'
+
+interface LoaderState {
+  promise: Promise<typeof AMap> | null
+  script?: HTMLScriptElement
+  config?: LoaderOptions
+}
+
+const state: LoaderState = {
+  promise: null
+}
+
+let defaults: Partial<LoaderOptions> = {}
+
+function buildScriptUrl(options: LoaderOptions): string {
+  const base = options.baseUrl ?? 'https://webapi.amap.com/maps'
+  const params = new URLSearchParams()
+  params.set('v', options.version ?? DEFAULT_VERSION)
+  params.set('key', options.key)
+  if (options.plugins?.length)
+    params.set('plugin', Array.from(new Set(options.plugins)).join(','))
+  if (options.serviceHost)
+    params.set('serviceHost', options.serviceHost)
+  return `${base}?${params.toString()}`
+}
+
+async function loadLoca(options: LoaderOptions) {
+  if (!options.loca)
+    return
+
+  const version = typeof options.loca === 'object' && options.loca?.version ? options.loca.version : DEFAULT_LOCA_VERSION
+  const url = `https://webapi.amap.com/loca?v=${version}&key=${options.key}`
+
+  if (!document.querySelector('script[data-amap-loca]')) {
+    await new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script')
+      script.src = url
+      script.async = true
+      script.dataset.amapLoca = 'true'
+      script.onload = () => resolve()
+      script.onerror = () => reject(new Error('Failed to load AMap Loca script'))
+      document.head.appendChild(script)
+    })
+  }
+}
+
+function resolveOptions(options?: Partial<LoaderOptions>): LoaderOptions {
+  const resolved: LoaderOptions = {
+    version: DEFAULT_VERSION,
+    ...defaults,
+    ...options
+  } as LoaderOptions
+
+  invariant(resolved.key, 'AMap loader requires an API key. Call loader.config({ key }) before loading.')
+  return resolved
+}
+
+function createLoadPromise(options: LoaderOptions) {
+  const existing = (window as any).AMap as typeof AMap | undefined
+  if (existing)
+    return Promise.resolve(existing)
+
+  if (options.securityJsCode) {
+    (window as any)._AMapSecurityConfig = {
+      securityJsCode: options.securityJsCode
+    }
+  }
+
+  if (state.script)
+    return new Promise<typeof AMap>((resolve, reject) => {
+      state.script?.addEventListener('load', () => {
+        const instance = (window as any).AMap as typeof AMap | undefined
+        if (instance)
+          resolve(instance)
+        else
+          reject(new Error('AMap JSAPI loaded but did not expose the global `AMap` object.'))
+      })
+      state.script?.addEventListener('error', () => {
+        state.promise = null
+        reject(new Error('Failed to load the AMap JSAPI script.'))
+      })
+    })
+
+  return new Promise<typeof AMap>((resolve, reject) => {
+    const script = document.createElement('script')
+    script.type = 'text/javascript'
+    script.async = true
+    script.dataset.amapLoader = 'true'
+    script.src = buildScriptUrl(options)
+
+    script.onload = () => {
+      const instance = (window as any).AMap as typeof AMap | undefined
+      if (instance)
+        resolve(instance)
+      else
+        reject(new Error('AMap JSAPI loaded but did not expose the global `AMap` object.'))
+    }
+    script.onerror = () => {
+      state.promise = null
+      script.remove()
+      reject(new Error('Failed to load the AMap JSAPI script.'))
+    }
+
+    document.head.appendChild(script)
+    state.script = script
+  })
+}
+
+export function createLoader() {
+  return {
+    config(options: Partial<LoaderOptions>) {
+      defaults = {
+        ...defaults,
+        ...options
+      }
+    },
+    get(): typeof AMap | undefined {
+      return isClient ? (window as any).AMap as typeof AMap | undefined : undefined
+    },
+    isLoaded(): boolean {
+      return Boolean(isClient && (window as any).AMap)
+    },
+    getConfig(): Partial<LoaderOptions> {
+      return { ...defaults }
+    },
+    async load(options?: Partial<LoaderOptions>): Promise<typeof AMap> {
+      invariant(isClient, 'AMap loader can only run in a browser environment.')
+      const resolved = resolveOptions(options)
+
+      if (state.promise) {
+        if (state.config) {
+          const { key, version, plugins = [] } = state.config
+          if ((key && key !== resolved.key) || (version && version !== resolved.version))
+            warn('Attempted to call loader.load() with a configuration that differs from the initial call. Existing configuration will be reused.')
+
+          if (resolved.plugins) {
+            const merged = new Set([...(state.config.plugins ?? []), ...resolved.plugins])
+            resolved.plugins = Array.from(merged)
+          }
+        }
+
+        return state.promise
+      }
+
+      const promise = createLoadPromise(resolved)
+        .then(async (AMapInstance) => {
+          state.config = resolved
+          await loadLoca(resolved)
+          return AMapInstance
+        })
+      state.promise = promise
+      return promise
+    }
+  }
+}
+
+export const loader = createLoader()
+
+export type { LoaderOptions }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,42 @@
+import type { ShallowRef } from 'vue'
+
+export type LngLatLike = AMap.LngLat | [number, number]
+export type PixelLike = AMap.Pixel | [number, number]
+
+export type ReadyCallback = (map: AMap.Map) => void
+
+export interface MapInjectionContext {
+  map: ShallowRef<AMap.Map | null>
+  ready: (callback: ReadyCallback) => void
+}
+
+export interface LoaderOptions {
+  /**
+   * The API key obtained from the AMap developer console.
+   */
+  key: string
+  /**
+   * JSAPI version, defaults to `2.0`.
+   */
+  version?: string
+  /**
+   * Plugin list passed to the loader.
+   */
+  plugins?: string[]
+  /**
+   * Optional security JS code for JSAPI 2.x applications with enhanced security enabled.
+   */
+  securityJsCode?: string
+  /**
+   * Optional custom service host, for private deployments.
+   */
+  serviceHost?: string
+  /**
+   * Whether to also load the Loca library. Pass `true` for default or provide the version.
+   */
+  loca?: boolean | { version?: string }
+  /**
+   * Custom base URL of the JSAPI script.
+   */
+  baseUrl?: string
+}

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,0 +1,33 @@
+import type { LngLatLike, PixelLike } from './types'
+
+export const isClient = typeof window !== 'undefined'
+
+export function toLngLat<AMapType extends typeof AMap>(AMap: AMapType, value: LngLatLike | undefined | null): AMap.LngLat | undefined {
+  if (!value)
+    return undefined
+
+  if (Array.isArray(value))
+    return new AMap.LngLat(value[0], value[1])
+
+  return value
+}
+
+export function toPixel<AMapType extends typeof AMap>(AMap: AMapType, value: PixelLike | undefined | null): AMap.Pixel | undefined {
+  if (!value)
+    return undefined
+
+  if (Array.isArray(value))
+    return new AMap.Pixel(value[0], value[1])
+
+  return value
+}
+
+export function warn(message: string) {
+  if (process.env.NODE_ENV !== 'production')
+    console.warn(`[amap-vue] ${message}`)
+}
+
+export function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition)
+    throw new Error(`[amap-vue] ${message}`)
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "tests", "**/*.test.ts"]
+}

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -1,0 +1,24 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es'],
+      fileName: () => 'index.js'
+    },
+    rollupOptions: {
+      external: ['vue']
+    }
+  },
+  plugins: [
+    dts({
+      entryRoot: 'src',
+      outputDir: 'dist',
+      insertTypesEntry: true
+    })
+  ]
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - packages/*
+  - docs
+  - examples/*
+  - .changeset

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "vite/client"
+    ]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/shared" },
+    { "path": "packages/hooks" },
+    { "path": "packages/core" },
+    { "path": "docs" },
+    { "path": "examples/basic" }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@amap-vue/core': resolve(__dirname, 'packages/core/src'),
+      '@amap-vue/hooks': resolve(__dirname, 'packages/hooks/src'),
+      '@amap-vue/shared': resolve(__dirname, 'packages/shared/src')
+    }
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: [resolve(__dirname, 'vitest.setup.ts')],
+    globals: true
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,294 @@
+import { loader } from '@amap-vue/shared'
+
+class EventTarget {
+  private listeners = new Map<string, Set<(event: any) => void>>()
+
+  on(event: string, handler: (event: any) => void) {
+    if (!this.listeners.has(event))
+      this.listeners.set(event, new Set())
+    this.listeners.get(event)!.add(handler)
+  }
+
+  off(event: string, handler: (event: any) => void) {
+    this.listeners.get(event)?.delete(handler)
+  }
+
+  emit(event: string, payload: any) {
+    this.listeners.get(event)?.forEach(handler => handler(payload))
+  }
+}
+
+class LngLat {
+  constructor(public lng: number, public lat: number) {}
+  getLng() {
+    return this.lng
+  }
+  getLat() {
+    return this.lat
+  }
+}
+
+class Pixel {
+  constructor(public x: number, public y: number) {}
+  getX() {
+    return this.x
+  }
+  getY() {
+    return this.y
+  }
+}
+
+class Map extends EventTarget {
+  public options: any
+  public status: Record<string, any> = {}
+  public destroyed = false
+
+  constructor(public container: HTMLElement, options: any = {}) {
+    super()
+    this.options = { ...options }
+  }
+
+  setCenter(value: any) {
+    this.options.center = value
+  }
+
+  setZoom(value: number) {
+    this.options.zoom = value
+  }
+
+  setPitch(value: number) {
+    this.options.pitch = value
+  }
+
+  setRotation(value: number) {
+    this.options.rotation = value
+  }
+
+  setMapStyle(value: string) {
+    this.options.mapStyle = value
+  }
+
+  setTheme(value: string) {
+    this.options.theme = value
+  }
+
+  setStatus(status: Record<string, any>) {
+    this.status = { ...this.status, ...status }
+  }
+
+  destroy() {
+    this.destroyed = true
+  }
+}
+
+class Marker extends EventTarget {
+  public map: Map | null
+  public options: any
+
+  constructor(options: any = {}) {
+    super()
+    this.map = options.map ?? null
+    this.options = { ...options }
+  }
+
+  setMap(map: Map | null) {
+    this.map = map
+  }
+
+  setPosition(position: any) {
+    this.options.position = position
+  }
+
+  setIcon(icon: any) {
+    this.options.icon = icon
+  }
+
+  setLabel(label: any) {
+    this.options.label = label
+  }
+
+  setExtData(extData: any) {
+    this.options.extData = extData
+  }
+
+  setDraggable(draggable: boolean) {
+    this.options.draggable = draggable
+  }
+
+  setzIndex(zIndex: number) {
+    this.options.zIndex = zIndex
+  }
+
+  setOffset(offset: any) {
+    this.options.offset = offset
+  }
+
+  show() {
+    this.options.visible = true
+  }
+
+  hide() {
+    this.options.visible = false
+  }
+
+  destroy() {
+    this.map = null
+  }
+}
+
+class InfoWindow {
+  public content: any
+  public offset: any
+  public opened = false
+  public position: any
+  public map: Map | null = null
+
+  constructor(options: any = {}) {
+    this.content = options.content
+    this.offset = options.offset
+  }
+
+  setContent(content: any) {
+    this.content = content
+  }
+
+  setOffset(offset: any) {
+    this.offset = offset
+  }
+
+  setPosition(position: any) {
+    this.position = position
+  }
+
+  open(map: Map, position: any) {
+    this.map = map
+    this.position = position
+    this.opened = true
+  }
+
+  close() {
+    this.opened = false
+    this.map = null
+  }
+}
+
+class Polyline extends EventTarget {
+  public map: Map | null = null
+  public options: any
+
+  constructor(options: any = {}) {
+    super()
+    this.options = { ...options }
+    this.map = options.map ?? null
+  }
+
+  setMap(map: Map | null) {
+    this.map = map
+  }
+
+  setPath(path: any) {
+    this.options.path = path
+  }
+
+  setOptions(options: any) {
+    this.options = { ...this.options, ...options }
+  }
+
+  show() {
+    this.options.visible = true
+  }
+
+  hide() {
+    this.options.visible = false
+  }
+
+  destroy() {
+    this.map = null
+  }
+}
+
+class Polygon extends Polyline {}
+
+class Circle extends EventTarget {
+  public map: Map | null = null
+  public options: any
+
+  constructor(options: any = {}) {
+    super()
+    this.options = { ...options }
+    this.map = options.map ?? null
+  }
+
+  setMap(map: Map | null) {
+    this.map = map
+  }
+
+  setCenter(center: any) {
+    this.options.center = center
+  }
+
+  setRadius(radius: number) {
+    this.options.radius = radius
+  }
+
+  setOptions(options: any) {
+    this.options = { ...this.options, ...options }
+  }
+
+  show() {
+    this.options.visible = true
+  }
+
+  hide() {
+    this.options.visible = false
+  }
+
+  destroy() {
+    this.map = null
+  }
+}
+
+class MassMarks extends EventTarget {
+  public map: Map | null = null
+  public data: any
+  public style: any
+
+  constructor(data: any[] = [], options: any = {}) {
+    super()
+    this.data = data
+    this.style = options.style
+    this.map = options.map ?? null
+  }
+
+  setMap(map: Map | null) {
+    this.map = map
+  }
+
+  setData(data: any[]) {
+    this.data = data
+  }
+
+  setStyle(style: any) {
+    this.style = style
+  }
+
+  destroy() {
+    this.map = null
+  }
+}
+
+Object.assign(globalThis, {
+  AMap: {
+    Map,
+    Marker,
+    InfoWindow,
+    Polyline,
+    Polygon,
+    Circle,
+    MassMarks,
+    LngLat,
+    Pixel
+  }
+})
+
+loader.config({ key: 'test-key' })


### PR DESCRIPTION
## Summary
- introduce a shared loader with strict config checks plus cross-package TypeScript/Vite setup for the monorepo
- add composables for maps, markers, mass markers, and overlays to provide SSR-safe hooks
- ship the first set of Vue components, VitePress docs, and a Vite example project to exercise the API

## Testing
- ❌ `pnpm install` *(fails: unable to download pnpm via corepack because registry access is blocked in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cf9c9e5c008330a17e313378019ab3