### PR TITLE
feat: add heatmap support

### DIFF
--- a/packages/core/src/components/AmapHeatMap.vue
+++ b/packages/core/src/components/AmapHeatMap.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import type { UseHeatMapOptions } from '@amap-vue/hooks'
+import type { MapInjectionContext } from '@amap-vue/shared'
+import type { PropType } from 'vue'
+
+import { useHeatMap } from '@amap-vue/hooks'
+import { amapMapInjectionKey, warn } from '@amap-vue/shared'
+import { computed, inject, onBeforeUnmount, shallowRef, watch } from 'vue'
+
+defineOptions({
+  name: 'AmapHeatMap',
+})
+
+const props = defineProps({
+  data: {
+    type: Array as PropType<AMap.HeatMapDataPoint[]>,
+    default: () => [],
+  },
+  max: Number,
+  radius: Number,
+  gradient: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
+  },
+  opacity: {
+    type: Array as PropType<[number, number] | undefined>,
+    default: undefined,
+  },
+  visible: {
+    type: Boolean,
+    default: true,
+  },
+  options: {
+    type: Object as PropType<Partial<AMap.HeatMapOptions>>,
+    default: () => ({}),
+  },
+})
+
+const emit = defineEmits<{
+  ready: [heatMap: AMap.HeatMap]
+}>()
+
+const mapContext = inject<MapInjectionContext | null>(amapMapInjectionKey, null)
+
+if (!mapContext)
+  warn('<AmapHeatMap> must be used inside <AmapMap>.')
+
+const heatMapOptions = computed<UseHeatMapOptions>(() => {
+  const base: UseHeatMapOptions = {
+    ...props.options,
+    visible: props.visible,
+  }
+  if (props.radius != null)
+    base.radius = props.radius
+  if (props.gradient)
+    base.gradient = props.gradient
+  if (props.opacity)
+    base.opacity = props.opacity
+  if (props.max != null)
+    base.max = props.max
+  if (props.data)
+    base.data = props.data
+  return base
+})
+
+const heatMapApi = mapContext ? useHeatMap(() => mapContext.map.value, heatMapOptions) : null
+const heatMap = heatMapApi?.overlay ?? shallowRef<AMap.HeatMap | null>(null)
+
+if (heatMapApi) {
+  watch(heatMap, (value) => {
+    if (value)
+      emit('ready', value)
+  }, { immediate: true })
+}
+
+function setDataSet(dataSet: AMap.HeatMapDataSet) {
+  heatMapApi?.setDataSet(dataSet)
+}
+
+function addDataPoint(point: AMap.HeatMapDataPoint) {
+  heatMapApi?.addDataPoint(point)
+}
+
+function show() {
+  heatMapApi?.show()
+}
+
+function hide() {
+  heatMapApi?.hide()
+}
+
+function setOptions(options: Partial<AMap.HeatMapOptions>) {
+  heatMapApi?.setOptions(options)
+}
+
+onBeforeUnmount(() => {
+  heatMapApi?.destroy()
+})
+
+defineExpose({
+  heatMap,
+  setDataSet,
+  addDataPoint,
+  show,
+  hide,
+  setOptions,
+})
+</script>
+
+<template>
+  <span v-if="false" />
+</template>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ import type { App } from 'vue'
 
 import AmapCircle from './components/AmapCircle.vue'
 import AmapControlBar from './components/AmapControlBar.vue'
+import AmapHeatMap from './components/AmapHeatMap.vue'
 import AmapInfoWindow from './components/AmapInfoWindow.vue'
 import AmapLabelMarker from './components/AmapLabelMarker.vue'
 import AmapLabelsLayer from './components/AmapLabelsLayer.vue'
@@ -21,6 +22,7 @@ import AmapTrafficLayer from './components/AmapTrafficLayer.vue'
 export {
   AmapCircle,
   AmapControlBar,
+  AmapHeatMap,
   AmapInfoWindow,
   AmapLabelMarker,
   AmapLabelsLayer,
@@ -47,6 +49,7 @@ const components = [
   AmapPolygon,
   AmapCircle,
   AmapLabelsLayer,
+  AmapHeatMap,
   AmapTileLayer,
   AmapTrafficLayer,
   AmapSatelliteLayer,

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,6 @@
 export * from './useCircle'
 export * from './useControl'
+export * from './useHeatMap'
 export * from './useInfoWindow'
 export * from './useLabelMarker'
 export * from './useLabelsLayer'

--- a/packages/hooks/src/useHeatMap.ts
+++ b/packages/hooks/src/useHeatMap.ts
@@ -1,0 +1,169 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { OverlayLifecycle } from './useOverlay'
+
+import { computed, toValue } from 'vue'
+import { useOverlay } from './useOverlay'
+
+export interface UseHeatMapOptions extends Partial<AMap.HeatMapOptions> {
+  visible?: boolean
+  data?: AMap.HeatMapDataPoint[]
+  max?: number
+}
+
+export interface UseHeatMapReturn extends OverlayLifecycle<AMap.HeatMap> {
+  show: () => void
+  hide: () => void
+  setOptions: (options: Partial<AMap.HeatMapOptions>) => void
+  setDataSet: (dataSet: AMap.HeatMapDataSet) => void
+  addDataPoint: (point: AMap.HeatMapDataPoint) => void
+}
+
+interface HeatMapState {
+  data?: AMap.HeatMapDataPoint[]
+  max?: number
+  visible?: boolean
+}
+
+function hasOwn(target: object, key: PropertyKey) {
+  return Object.prototype.hasOwnProperty.call(target, key)
+}
+
+function buildDataSet(data: AMap.HeatMapDataPoint[] | undefined, max: number | undefined): AMap.HeatMapDataSet | null {
+  if (data == null && max == null)
+    return null
+  const dataset: AMap.HeatMapDataSet = { data: data ?? [] }
+  if (max != null)
+    dataset.max = max
+  return dataset
+}
+
+function applyHeatMapOptions(
+  instance: AMap.HeatMap,
+  options: UseHeatMapOptions,
+  state: HeatMapState,
+) {
+  const { visible, data, max, ...rest } = options
+  const hasData = hasOwn(options, 'data')
+  const hasMax = hasOwn(options, 'max')
+
+  if (Object.keys(rest).length)
+    (instance as any).setOptions?.(rest)
+
+  if (hasData)
+    state.data = data
+  if (hasMax)
+    state.max = max
+
+  if (hasData || (hasMax && state.data !== undefined)) {
+    const dataset = buildDataSet(state.data, hasMax ? max : state.max)
+    if (dataset)
+      (instance as any).setDataSet?.(dataset)
+  }
+
+  if (visible != null) {
+    state.visible = visible
+    if (visible)
+      (instance as any).show?.()
+    else
+      (instance as any).hide?.()
+  }
+}
+
+export function useHeatMap(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<UseHeatMapOptions>,
+): UseHeatMapReturn {
+  const optionsRef = computed<UseHeatMapOptions>(() => ({
+    ...(toValue(options) as UseHeatMapOptions | undefined ?? {}),
+  }))
+
+  const state: HeatMapState = {}
+  const initialOptions = optionsRef.value
+  if (hasOwn(initialOptions, 'data'))
+    state.data = initialOptions.data
+  if (hasOwn(initialOptions, 'max'))
+    state.max = initialOptions.max
+  if (hasOwn(initialOptions, 'visible'))
+    state.visible = initialOptions.visible
+
+  const overlay = useOverlay(
+    mapRef,
+    optionsRef,
+    ({ AMap, map, options: heatMapOptions }) => {
+      const { visible, data, max, ...rest } = heatMapOptions
+
+      if (hasOwn(heatMapOptions, 'data'))
+        state.data = data
+      if (hasOwn(heatMapOptions, 'max'))
+        state.max = max
+      if (hasOwn(heatMapOptions, 'visible'))
+        state.visible = visible
+
+      const instance = new (AMap as any).HeatMap(map, rest)
+      const dataset = buildDataSet(state.data, state.max)
+      if (dataset)
+        (instance as any).setDataSet?.(dataset)
+      if (state.visible === false)
+        instance.hide?.()
+      return instance
+    },
+    (instance, nextOptions) => {
+      applyHeatMapOptions(instance, nextOptions, state)
+    },
+    () => ({ plugins: ['AMap.HeatMap'] }),
+  )
+
+  function show() {
+    state.visible = true
+    overlay.overlay.value?.show?.()
+  }
+
+  function hide() {
+    state.visible = false
+    overlay.overlay.value?.hide?.()
+  }
+
+  function setOptions(options: Partial<AMap.HeatMapOptions>) {
+    if (!options)
+      return
+    overlay.overlay.value?.setOptions?.(options)
+  }
+
+  function setDataSet(dataSet: AMap.HeatMapDataSet) {
+    if (!dataSet || !Array.isArray(dataSet.data))
+      return
+    state.data = dataSet.data
+    if (hasOwn(dataSet, 'max'))
+      state.max = dataSet.max
+    const instance = overlay.overlay.value
+    if (!instance)
+      return
+    const dataset = buildDataSet(state.data, state.max)
+    if (dataset)
+      (instance as any).setDataSet?.(dataset)
+  }
+
+  function addDataPoint(point: AMap.HeatMapDataPoint) {
+    if (!point)
+      return
+    const instance = overlay.overlay.value as any
+    if (!instance)
+      return
+    const { lng, lat, count } = point
+    if (lng == null || lat == null || count == null)
+      return
+    instance.addDataPoint?.(lng, lat, count)
+    const current = Array.isArray(state.data) ? state.data.slice() : []
+    current.push(point)
+    state.data = current
+  }
+
+  return {
+    ...overlay,
+    show,
+    hide,
+    setOptions,
+    setDataSet,
+    addDataPoint,
+  }
+}

--- a/packages/shared/src/amap-extensions.d.ts
+++ b/packages/shared/src/amap-extensions.d.ts
@@ -89,6 +89,39 @@ declare global {
       off(event: string, handler: (event: any) => void): void
       destroy(): void
     }
+
+    interface HeatMapOptions {
+      radius?: number
+      gradient?: Record<string, string>
+      opacity?: [number, number]
+      zooms?: [number, number]
+      zIndex?: number
+      [key: string]: any
+    }
+
+    interface HeatMapDataPoint {
+      lng: number
+      lat: number
+      count: number
+    }
+
+    interface HeatMapDataSet {
+      data: HeatMapDataPoint[]
+      max?: number
+    }
+
+    class HeatMap {
+      constructor(map: Map, options?: HeatMapOptions)
+      setMap(map: Map | null): void
+      setOptions(options: Partial<HeatMapOptions>): void
+      setDataSet(dataSet: HeatMapDataSet): void
+      addDataPoint(lng: number, lat: number, count: number): void
+      show(): void
+      hide(): void
+      on(event: string, handler: (event: any) => void): void
+      off(event: string, handler: (event: any) => void): void
+      destroy(): void
+    }
   }
 }
 

--- a/todo.md
+++ b/todo.md
@@ -17,7 +17,7 @@
   * [x] `shared`：AMap 脚本单例加载器 `loadAmap()`
 * [x] **M1 — MVP 基础组件/Hook（Map/Marker/InfoWindow/Polyline/Polygon/Circle）**
 * [x] **M2 — 图层 & 控件（TileLayer/Traffic/Satellite/RoadNet + ToolBar/Scale/ControlBar）**
-* [ ] **M3 — Labels 系列 & 高性能（LabelsLayer/LabelMarker + OverlayGroup 批量）**
+* [x] **M3 — Labels 系列 & 高性能（LabelsLayer/LabelMarker + OverlayGroup 批量）**
 * [ ] **M4 — 编辑器 & 热力图（Circle/Rectangle/Ellipse Editor + HeatMap）**
 * [ ] **M5 — 文档站完善、示例、性能指南、对比页、首次发布**
 
@@ -181,9 +181,9 @@ amap-vue-kit/
 
 ### D. 标签与高性能（M3）
 
-* [ ] **`<AmapLabelsLayer>`**（容器，provide layer）
+* [x] **`<AmapLabelsLayer>`**（容器，provide layer）
 
-* [ ] **`<AmapLabelMarker>`**（作为子节点，inject layer）
+* [x] **`<AmapLabelMarker>`**（作为子节点，inject layer）
 
   * props：`position`, `text`, `icon`, `zIndex`, `zoom?`, `collision?`
   * **AI 提示词：**
@@ -194,7 +194,7 @@ amap-vue-kit/
     - 支持碰撞避让/透明度/批量增删（可配合 hooks）
     ```
 
-* [ ] **`<AmapOverlayGroup>`**（批量增删/清理容器）
+* [x] **`<AmapOverlayGroup>`**（批量增删/清理容器）
 
   * **AI 提示词：**
 
@@ -222,7 +222,7 @@ amap-vue-kit/
     - target 变更后重绑定；事件转发为 emits
     ```
 
-* [ ] **`<AmapHeatMap>`**
+* [x] **`<AmapHeatMap>`**
 
   * props：`data`, `radius`, `gradient`, `max`
   * **AI 提示词：**
@@ -256,15 +256,15 @@ amap-vue-kit/
 
 * [x] **`usePolyline / usePolygon / useCircle`**
 
-* [ ] **`useTileLayer / useTrafficLayer / useRoadNetLayer / useSatelliteLayer`**
+* [x] **`useTileLayer / useTrafficLayer / useRoadNetLayer / useSatelliteLayer`**
 
-* [ ] **`useLabelsLayer / useLabelMarker`**
+* [x] **`useLabelsLayer / useLabelMarker`**
 
-* [ ] **`useOverlayGroup`**
+* [x] **`useOverlayGroup`**
 
 * [ ] **`useEditorCircle / useEditorRectangle / useEditorEllipse`**
 
-* [ ] **`useHeatMap`**
+* [x] **`useHeatMap`**
 
 * [ ] 覆盖物 hooks 单元测试：`useInfoWindow` / `usePolyline` / `usePolygon` / `useCircle`
 * [ ] 文档：新增 hooks 页面（`use-info-window`、`use-polyline`、`use-polygon`、`use-circle`）
@@ -339,7 +339,7 @@ amap-vue-kit/
 * [ ] LabelsLayer/LabelMarker 支撑千级点，不明显卡顿
 * [ ] OverlayGroup 一次性增删上千覆盖物成功
 * [ ] 三种 Editor 可开关编辑，事件上报
-* [ ] HeatMap 数据集可动态变更
+* [x] HeatMap 数据集可动态变更
 * [ ] hooks 与组件 API 对应、文档同步
 * [ ] 文档站：入门 5 分钟能跑；页面齐备；动图与 StackBlitz 可用
 * [ ] CI 全绿；首次 npm 发布成功；版本与文档一致


### PR DESCRIPTION
## Summary
- add a `useHeatMap` hook that loads the plugin, keeps dataset/visibility state, and exposes imperative helpers
- introduce an `<AmapHeatMap>` component that consumes the hook and expose the underlying instance utilities; export it from core
- extend shared AMap typings for heatmap and update the project TODO to reflect the completed labels and heatmap work

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck *(fails: existing TS config lacks global AMap types and composite project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cfec66e5148330b53a43fb2739e5dd