### PR TITLE
Refine overlay hook tests and add hook docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
           items: [
             { text: 'useMap', link: '/hooks/use-map' },
             { text: 'useMarker', link: '/hooks/use-marker' },
+            { text: 'useInfoWindow', link: '/hooks/use-info-window' },
+            { text: 'usePolyline', link: '/hooks/use-polyline' },
+            { text: 'usePolygon', link: '/hooks/use-polygon' },
+            { text: 'useCircle', link: '/hooks/use-circle' },
             { text: 'useOverlay', link: '/hooks/use-overlay' },
           ],
         },

--- a/docs/hooks/use-circle.md
+++ b/docs/hooks/use-circle.md
@@ -1,0 +1,38 @@
+# `useCircle`
+
+Control circular overlays reactively. The hook keeps the center and radius synchronized with Vue state, normalizes `LngLatLike` values, and handles visibility toggling.
+
+```ts
+import { ref } from 'vue'
+import { useCircle } from '@amap-vue/hooks'
+
+const circleOptions = ref({
+  center: [116.397, 39.908],
+  radius: 500,
+  strokeColor: '#ff6d00',
+  fillColor: 'rgba(255, 109, 0, 0.2)',
+})
+
+const circleApi = useCircle(() => map.value, circleOptions)
+
+circleApi.on('dragend', () => {
+  console.log('circle moved')
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.Circle \| null>` referencing the circle instance. |
+| `setCenter` | Update the center with `LngLatLike` input; values are converted to `AMap.LngLat`. |
+| `setRadius` | Adjust the radius in meters. |
+| `setOptions` | Proxy to `Circle#setOptions` for styling updates. |
+| `setExtData` | Attach arbitrary metadata to the circle. |
+| `show` / `hide` | Toggle visibility without destroying the overlay. |
+| `destroy` | Remove the circle from the map and tear down listeners. |
+
+### Notes
+
+- Setting the reactive `visible` option hides or shows the circle automatically.
+- When the map reference becomes `null`, the circle detaches itself and reattaches once a map instance is available again.

--- a/docs/hooks/use-info-window.md
+++ b/docs/hooks/use-info-window.md
@@ -1,0 +1,37 @@
+# `useInfoWindow`
+
+Imperatively manage JSAPI info windows with Vue reactivity. The composable delays instantiation until both the map and loader are ready, keeps the open state in sync, and cleans up automatically on unmount.
+
+```ts
+import { ref } from 'vue'
+import { useInfoWindow } from '@amap-vue/hooks'
+
+const options = ref({
+  position: [116.397, 39.908],
+  content: 'Hello AMap',
+  open: true,
+  offset: [12, 16],
+})
+
+const infoWindowApi = useInfoWindow(() => map.value, options)
+
+infoWindowApi.on('open', () => {
+  console.log('info window opened')
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `infoWindow` | `ShallowRef<AMap.InfoWindow \| null>` referencing the underlying instance. |
+| `open` / `close` | Programmatically toggle visibility while keeping the reactive `open` flag in sync. |
+| `setPosition`, `setOffset`, `setAnchor`, `setIsCustom`, `setContent` | Typed helpers that proxy to the matching JSAPI methods and accept Vue-friendly inputs (`LngLatLike`, `PixelLike`). |
+| `setOptions` | Batch update any other option via `InfoWindow#setOptions`. |
+| `on` / `off` | Subscribe to and remove JSAPI event listeners. |
+| `destroy` | Dispose the info window and clear internal state. |
+
+### Notes
+
+- Passing reactive `open`, `position`, or `content` options keeps the JSAPI instance in sync without manual watchers.
+- When the provided map reference becomes `null`, the info window closes itself and reattaches once a map is available again.

--- a/docs/hooks/use-polygon.md
+++ b/docs/hooks/use-polygon.md
@@ -1,0 +1,37 @@
+# `usePolygon`
+
+Manage polygons (single or multi-ring) through Vue reactivity. The hook normalizes the supplied path, keeps visibility in sync, and cleans up automatically.
+
+```ts
+import { ref } from 'vue'
+import { usePolygon } from '@amap-vue/hooks'
+
+const polygonOptions = ref({
+  path: [
+    [116.38, 39.9],
+    [116.41, 39.91],
+    [116.4, 39.94],
+  ],
+  fillOpacity: 0.3,
+})
+
+const polygonApi = usePolygon(() => map.value, polygonOptions)
+
+polygonApi.setExtData({ regionId: 'beijing-core' })
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.Polygon \| null>` referencing the active polygon instance. |
+| `setPath` | Accepts either a simple ring (`LngLatLike[]`) or an array of rings and converts them into `AMap.LngLat` objects. |
+| `setOptions` | Forward additional option updates to `Polygon#setOptions`. |
+| `setExtData` | Attach arbitrary metadata to the polygon. |
+| `show` / `hide` | Toggle visibility without disposing the overlay. |
+| `destroy` | Remove the polygon from the map and free listeners. |
+
+### Notes
+
+- The `path` option can be reactive and represent holes or multiple rings. Each segment is normalized to JSAPI coordinates.
+- Setting `visible` to `false` hides the polygon until the flag is flipped back to `true`.

--- a/docs/hooks/use-polyline.md
+++ b/docs/hooks/use-polyline.md
@@ -1,0 +1,39 @@
+# `usePolyline`
+
+Create and update JSAPI polylines declaratively from Vue state. Paths are normalized from `LngLatLike[]` and the instance reattaches when the map reference changes.
+
+```ts
+import { ref } from 'vue'
+import { usePolyline } from '@amap-vue/hooks'
+
+const path = ref([
+  [116.38, 39.9],
+  [116.41, 39.92],
+])
+
+const polylineApi = usePolyline(() => map.value, () => ({
+  path: path.value,
+  strokeColor: '#2979ff',
+  strokeWeight: 4,
+}))
+
+polylineApi.on('click', () => {
+  console.log('polyline clicked')
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.Polyline \| null>` pointing to the active polyline instance. |
+| `setPath` | Replace the polyline path with an array of `LngLatLike` coordinates. Values are converted to `AMap.LngLat`. |
+| `setOptions` | Call `Polyline#setOptions` for bulk option updates (style, zIndex, etc.). |
+| `setExtData` | Store arbitrary metadata on the overlay. |
+| `show` / `hide` | Toggle the visibility flag without destroying the instance. |
+| `destroy` | Remove the polyline from the map and release listeners. |
+
+### Notes
+
+- The composable watches the reactive options and updates the JSAPI object incrementally, so you can mutate `path.value` or `strokeColor` without manual glue code.
+- Setting `visible: false` in the options will hide the overlay until the flag becomes truthy again.

--- a/packages/hooks/tests/overlay-hooks.test.ts
+++ b/packages/hooks/tests/overlay-hooks.test.ts
@@ -1,0 +1,345 @@
+import type { Ref } from 'vue'
+
+import { flushPromises as flushPendingPromises, mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import type { UseCircleOptions } from '../src/useCircle'
+import type { UseInfoWindowOptions } from '../src/useInfoWindow'
+import type { UsePolygonOptions } from '../src/usePolygon'
+import type { UsePolylineOptions } from '../src/usePolyline'
+
+import { useCircle } from '../src/useCircle'
+import { useInfoWindow } from '../src/useInfoWindow'
+import { usePolygon } from '../src/usePolygon'
+import { usePolyline } from '../src/usePolyline'
+
+function createContainer() {
+  const container = document.createElement('div')
+  container.style.width = '400px'
+  container.style.height = '300px'
+  document.body.appendChild(container)
+  return container
+}
+
+function createMap() {
+  const container = createContainer()
+  const map = new AMap.Map(container)
+  return {
+    map,
+    cleanup() {
+      container.remove()
+    },
+  }
+}
+
+async function flushReactivity() {
+  await flushPendingPromises()
+  await nextTick()
+}
+
+async function waitForInstance<T>(getter: () => T | null | undefined, attempts = 5): Promise<T> {
+  for (let index = 0; index < attempts; index++) {
+    const value = getter()
+    if (value)
+      return value
+    await flushReactivity()
+  }
+
+  const value = getter()
+  if (!value)
+    throw new Error('Timed out waiting for instance to be created')
+  return value
+}
+
+interface HookHarness<Options, HookReturn> {
+  hook: HookReturn
+  map: AMap.Map
+  mapRef: Ref<AMap.Map | null>
+  options: Ref<Options>
+  cleanup: () => void
+}
+
+function mountHookWithMap<Options, HookReturn>(
+  factory: (mapRef: Ref<AMap.Map | null>, options: Ref<Options>) => HookReturn,
+  initialOptions: Options,
+): HookHarness<Options, HookReturn> {
+  const { map, cleanup: disposeMap } = createMap()
+  const context: Partial<HookHarness<Options, HookReturn>> = {}
+
+  const TestComponent = defineComponent({
+    setup() {
+      const mapRef = ref<AMap.Map | null>(map)
+      const optionsRef = ref(initialOptions) as Ref<Options>
+      const hook = factory(mapRef, optionsRef)
+
+      Object.assign(context, {
+        hook,
+        map,
+        mapRef,
+        options: optionsRef,
+      })
+
+      return () => null
+    },
+  })
+
+  const wrapper = mount(TestComponent)
+
+  return {
+    hook: context.hook!,
+    map,
+    mapRef: context.mapRef!,
+    options: context.options!,
+    cleanup() {
+      wrapper.unmount()
+      disposeMap()
+    },
+  }
+}
+
+describe('useInfoWindow', () => {
+  it('creates and updates an info window instance', async () => {
+    const harness = mountHookWithMap<UseInfoWindowOptions, ReturnType<typeof useInfoWindow>>(
+      (mapRef, options) => useInfoWindow(mapRef, options),
+      {
+        position: [116.391, 39.907],
+        open: true,
+        content: 'Hello',
+        offset: [12, 24],
+        anchor: 'bottom-center',
+      },
+    )
+
+    const instance = await waitForInstance(() => harness.hook.infoWindow.value)
+    if (!instance)
+      throw new Error('InfoWindow instance was not created')
+
+    expect(instance).toBeInstanceOf(AMap.InfoWindow)
+    expect(instance.map?.container).toBe(harness.map.container)
+    expect(instance.opened).toBe(true)
+    expect(instance.position).toBeInstanceOf(AMap.LngLat)
+    expect(instance.content).toBe('Hello')
+    expect(instance.offset).toBeInstanceOf(AMap.Pixel)
+
+    harness.options.value = {
+      ...harness.options.value,
+      open: false,
+      content: 'Updated',
+      offset: [30, 40],
+    }
+    await flushReactivity()
+    expect(instance.opened).toBe(false)
+    expect(instance.content).toBe('Updated')
+    expect(instance.offset).toBeInstanceOf(AMap.Pixel)
+
+    harness.hook.setContent('Manual')
+    expect(instance.content).toBe('Manual')
+
+    harness.hook.setPosition([120, 30])
+    expect(instance.position).toBeInstanceOf(AMap.LngLat)
+
+    harness.hook.open()
+    expect(instance.opened).toBe(true)
+
+    harness.mapRef.value = null
+    await flushReactivity()
+    expect(instance.map).toBeNull()
+    expect(instance.opened).toBe(false)
+
+    harness.mapRef.value = harness.map
+    await flushReactivity()
+    expect(instance.map?.container).toBe(harness.map.container)
+
+    harness.hook.destroy()
+    expect(harness.hook.infoWindow.value).toBeNull()
+    harness.cleanup()
+  })
+})
+
+describe('usePolyline', () => {
+  it('manages a polyline overlay lifecycle', async () => {
+    const path: UsePolylineOptions['path'] = [
+      [116.38, 39.9],
+      [116.4, 39.92],
+    ]
+
+    const harness = mountHookWithMap<UsePolylineOptions, ReturnType<typeof usePolyline>>(
+      (mapRef, options) => usePolyline(mapRef, options),
+      {
+        path,
+        strokeWeight: 4,
+      },
+    )
+
+    const instance = await waitForInstance(() => harness.hook.overlay.value)
+    if (!instance)
+      throw new Error('Polyline instance was not created')
+
+    expect(instance).toBeInstanceOf(AMap.Polyline)
+    expect(instance.map?.container).toBe(harness.map.container)
+    expect(instance.options.path).toHaveLength(2)
+    expect(instance.options.path?.[0]).toBeInstanceOf(AMap.LngLat)
+
+    harness.options.value = {
+      ...harness.options.value,
+      visible: false,
+      path: [
+        [117.1, 40.1],
+        [117.3, 40.3],
+      ],
+    }
+    await flushReactivity()
+    expect(instance.options.visible).toBe(false)
+    expect(instance.options.path?.[0]).toBeInstanceOf(AMap.LngLat)
+
+    harness.hook.setExtData({ id: 'polyline' })
+    expect(instance.options.extData).toEqual({ id: 'polyline' })
+
+    harness.hook.hide()
+    expect(instance.options.visible).toBe(false)
+    harness.hook.show()
+    expect(instance.options.visible).toBe(true)
+
+    harness.hook.setPath([
+      [118.1, 41.1],
+      [118.2, 41.2],
+    ])
+    expect(instance.options.path?.[0]).toBeInstanceOf(AMap.LngLat)
+
+    harness.mapRef.value = null
+    await flushReactivity()
+    expect(instance.map).toBeNull()
+
+    harness.mapRef.value = harness.map
+    await flushReactivity()
+    expect(instance.map?.container).toBe(harness.map.container)
+
+    harness.hook.destroy()
+    expect(harness.hook.overlay.value).toBeNull()
+    expect(instance.map).toBeNull()
+    harness.cleanup()
+  })
+})
+
+describe('usePolygon', () => {
+  it('creates and updates polygon paths', async () => {
+    const harness = mountHookWithMap<UsePolygonOptions, ReturnType<typeof usePolygon>>(
+      (mapRef, options) => usePolygon(mapRef, options),
+      {
+        path: [
+          [116.38, 39.9],
+          [116.4, 39.92],
+          [116.42, 39.95],
+        ],
+      },
+    )
+
+    const instance = await waitForInstance(() => harness.hook.overlay.value)
+    if (!instance)
+      throw new Error('Polygon instance was not created')
+
+    expect(instance).toBeInstanceOf(AMap.Polygon)
+    expect(instance.map?.container).toBe(harness.map.container)
+    expect(Array.isArray(instance.options.path)).toBe(true)
+    expect((instance.options.path as any[])[0]).toBeInstanceOf(AMap.LngLat)
+
+    harness.options.value = {
+      ...harness.options.value,
+      path: [
+        [
+          [117.1, 40.1],
+          [117.2, 40.1],
+          [117.2, 40.2],
+        ],
+        [
+          [118.1, 41.1],
+          [118.2, 41.1],
+          [118.2, 41.2],
+        ],
+      ],
+      visible: false,
+    }
+    await flushReactivity()
+
+    expect(instance.options.visible).toBe(false)
+    const nextPath = instance.options.path as any[]
+    expect(Array.isArray(nextPath[0])).toBe(true)
+    expect(nextPath[0][0]).toBeInstanceOf(AMap.LngLat)
+
+    harness.hook.setExtData({ id: 'polygon' })
+    expect(instance.options.extData).toEqual({ id: 'polygon' })
+
+    harness.hook.hide()
+    expect(instance.options.visible).toBe(false)
+    harness.hook.show()
+    expect(instance.options.visible).toBe(true)
+
+    harness.hook.destroy()
+    expect(harness.hook.overlay.value).toBeNull()
+    expect(instance.map).toBeNull()
+    harness.cleanup()
+  })
+})
+
+describe('useCircle', () => {
+  it('tracks circle updates and visibility', async () => {
+    const harness = mountHookWithMap<UseCircleOptions, ReturnType<typeof useCircle>>(
+      (mapRef, options) => useCircle(mapRef, options),
+      {
+        center: [116.38, 39.9],
+        radius: 500,
+        visible: false,
+      },
+    )
+
+    const instance = await waitForInstance(() => harness.hook.overlay.value)
+    if (!instance)
+      throw new Error('Circle instance was not created')
+
+    expect(instance).toBeInstanceOf(AMap.Circle)
+    expect(instance.map?.container).toBe(harness.map.container)
+    expect(instance.options.center).toBeInstanceOf(AMap.LngLat)
+    expect(instance.options.radius).toBe(500)
+    expect(instance.options.visible).toBe(false)
+
+    harness.options.value = {
+      ...harness.options.value,
+      radius: 800,
+      visible: true,
+    }
+    await flushReactivity()
+    expect(instance.options.radius).toBe(800)
+    expect(instance.options.visible).toBe(true)
+
+    harness.hook.setCenter([120.1, 30.2])
+    expect(instance.options.center).toBeInstanceOf(AMap.LngLat)
+
+    harness.hook.setRadius(1000)
+    expect(instance.options.radius).toBe(1000)
+
+    harness.hook.setOptions({ strokeWeight: 6 })
+    expect(instance.options.strokeWeight).toBe(6)
+
+    harness.hook.setExtData({ id: 'circle' })
+    expect(instance.options.extData).toEqual({ id: 'circle' })
+
+    harness.hook.hide()
+    expect(instance.options.visible).toBe(false)
+    harness.hook.show()
+    expect(instance.options.visible).toBe(true)
+
+    harness.mapRef.value = null
+    await flushReactivity()
+    expect(instance.map).toBeNull()
+
+    harness.mapRef.value = harness.map
+    await flushReactivity()
+    expect(instance.map?.container).toBe(harness.map.container)
+
+    harness.hook.destroy()
+    expect(harness.hook.overlay.value).toBeNull()
+    expect(instance.map).toBeNull()
+    harness.cleanup()
+  })
+})

--- a/todo.md
+++ b/todo.md
@@ -266,8 +266,8 @@ amap-vue-kit/
 
 * [x] **`useHeatMap`**
 
-* [ ] 覆盖物 hooks 单元测试：`useInfoWindow` / `usePolyline` / `usePolygon` / `useCircle`
-* [ ] 文档：新增 hooks 页面（`use-info-window`、`use-polyline`、`use-polygon`、`use-circle`）
+* [x] 覆盖物 hooks 单元测试：`useInfoWindow` / `usePolyline` / `usePolygon` / `useCircle`
+* [x] 文档：新增 hooks 页面（`use-info-window`、`use-polyline`、`use-polygon`、`use-circle`）
 
   * **AI 通用提示词：**
 


### PR DESCRIPTION
## Summary
- refactor the overlay hook tests to mount composables inside a Vue component via a reusable harness, eliminating lifecycle warnings while keeping coverage of lifecycle behaviors
- document useInfoWindow, usePolyline, usePolygon, and useCircle in VitePress and wire the new pages into the hooks sidebar
- update the project todo to mark the overlay hook documentation task as complete

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cff7a04df88330a841b7d6de01c610