### PR TITLE
docs: add tile layer hooks guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,14 +27,31 @@ export default defineConfig({
       ],
       '/components/': [
         {
-          text: 'Map',
+          text: 'A · Basics & Overlays',
           items: [
             { text: 'Map', link: '/components/map' },
             { text: 'Marker', link: '/components/marker' },
             { text: 'Info Window', link: '/components/info-window' },
+          ],
+        },
+        {
+          text: 'A · Geometry',
+          items: [
             { text: 'Polyline', link: '/components/polyline' },
             { text: 'Polygon', link: '/components/polygon' },
             { text: 'Circle', link: '/components/circle' },
+          ],
+        },
+        {
+          text: 'B · Layers',
+          items: [
+            { text: 'Tile Layers', link: '/components/tile-layer' },
+          ],
+        },
+        {
+          text: 'C · Controls',
+          items: [
+            { text: 'Map Controls', link: '/components/map-controls' },
           ],
         },
       ],
@@ -48,6 +65,7 @@ export default defineConfig({
             { text: 'usePolyline', link: '/hooks/use-polyline' },
             { text: 'usePolygon', link: '/hooks/use-polygon' },
             { text: 'useCircle', link: '/hooks/use-circle' },
+            { text: 'useTileLayer', link: '/hooks/use-tile-layer' },
             { text: 'useOverlay', link: '/hooks/use-overlay' },
           ],
         },

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -23,3 +23,34 @@
   color: var(--vp-c-text-2);
   background: var(--vp-c-bg-alt);
 }
+
+.amap-demo__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--amap-demo-border);
+  background: var(--vp-c-bg-soft);
+  font-size: 0.875rem;
+}
+
+.amap-demo__toolbar label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.amap-demo__toolbar select {
+  appearance: none;
+  border-radius: 6px;
+  border: 1px solid var(--amap-demo-border);
+  padding: 0.2rem 0.75rem 0.2rem 0.45rem;
+  background: var(--vp-c-bg);
+  color: inherit;
+}
+
+.amap-demo__toolbar input[type='checkbox'] {
+  width: 0.95rem;
+  height: 0.95rem;
+  accent-color: var(--vp-c-brand-1);
+}

--- a/docs/components/map-controls.md
+++ b/docs/components/map-controls.md
@@ -1,0 +1,118 @@
+# `<AmapToolBar>`, `<AmapScale>`, `<AmapControlBar>`, `<AmapMapType>`
+
+These wrapper components expose the built-in JSAPI map controls so you can toggle navigation chrome without writing imperative code. Each control automatically loads the required plugin, attaches itself to the nearest `<AmapMap>`, and tears down on unmount.
+
+## Shared props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `visible` | `boolean` | `true` | Shows or hides the control without destroying it. |
+| `position` | `'LT' \| 'RT' \| 'LB' \| 'RB' \| undefined` | – | Corner of the map to anchor to (Left/Right × Top/Bottom). |
+| `offset` | `PixelLike \| undefined` | – | Pixel offset from the anchor corner. Accepts `[x, y]` arrays or `AMap.Pixel`. |
+| `options` | `Partial<UseToolBarOptions \| UseScaleOptions \| UseControlBarOptions \| UseMapTypeOptions>` | `{}` | Extra JSAPI options passed to the control. Each component narrows this union to its concrete hook type (see below). |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.ToolBar \| AMap.Scale \| AMap.ControlBar \| AMap.MapType` | Emits once the control is created and added to the map. |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const showZoomBar = ref(true)
+const showControlButton = ref(true)
+const mapTypeDefaultType = ref<0 | 1>(0)
+</script>
+
+<template>
+  <AmapMap :center="[116.397, 39.908]" :zoom="12" style="height: 320px">
+    <AmapToolBar position="RT" :offset="[16, 16]" />
+    <AmapScale :offset="[16, 86]" />
+    <AmapControlBar
+      :show-zoom-bar="showZoomBar"
+      :show-control-button="showControlButton"
+    />
+    <AmapMapType
+      :default-type="mapTypeDefaultType"
+      :show-traffic="false"
+      :show-road="true"
+    />
+  </AmapMap>
+</template>
+```
+
+Toggle the props reactively to reposition the controls, reveal advanced toggles, or hide them without destroying the underlying JSAPI instance.
+
+<ClientOnly>
+  <ControlsDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import ControlsDemo from '../examples/ControlsDemo.vue'
+</script>
+
+### Component-specific props
+
+- **`<AmapControlBar>`** — Accepts `showZoomBar` and `showControlButton` to fine-tune the zoom slider and rotation/tilt switch. Provide extra ControlBar options (such as `liteStyle`) through `options: Partial<UseControlBarOptions>`.
+- **`<AmapMapType>`** — Supports `defaultType` (0 = standard, 1 = satellite), `showTraffic`, and `showRoad` to expose quick toggles on the control. Additional MapType options (like custom layer lists) can also be passed via `options: Partial<UseMapTypeOptions>`.
+
+### Positioning tips
+
+- Align multiple controls by reusing the same `position` and staggering them with incremental `offset` values.
+- The offset `[x, y]` values are measured in CSS pixels from the anchor corner. Use positive `y` values to push controls downward when anchored at the top.
+- Controls can be mixed and matched—e.g. keep `<AmapToolBar>` on `RT` while anchoring `<AmapScale>` to `LB` to avoid overlapping overlays.
+
+### Common pitfalls
+
+- Controls must live within `<AmapMap>` so they can access the injected map context. A warning is emitted in development when the context is missing.
+- Loading the same control twice in one corner without adjusting `offset` will stack them. Offset each instance or hide duplicates based on breakpoints.
+- When pairing `<AmapMapType>` with `<AmapTrafficLayer>`, prefer the control's built-in traffic toggle (`showTraffic`) to avoid conflicting state.
+
+### TypeScript signature
+
+```ts
+export interface ToolBarProps {
+  visible?: boolean
+  position?: string
+  offset?: PixelLike
+  options?: Partial<UseToolBarOptions>
+}
+
+export interface ScaleProps {
+  visible?: boolean
+  position?: string
+  offset?: PixelLike
+  options?: Partial<UseScaleOptions>
+}
+
+export interface ControlBarProps {
+  visible?: boolean
+  position?: string
+  offset?: PixelLike
+  showZoomBar?: boolean
+  showControlButton?: boolean
+  options?: Partial<UseControlBarOptions>
+}
+
+export interface MapTypeProps {
+  visible?: boolean
+  position?: string
+  offset?: PixelLike
+  defaultType?: number
+  showTraffic?: boolean
+  showRoad?: boolean
+  options?: Partial<UseMapTypeOptions>
+}
+
+type ControlReadyPayload = AMap.ToolBar | AMap.Scale | AMap.ControlBar | AMap.MapType
+```
+
+These interfaces reuse the shared `PixelLike` type from `@amap-vue/shared` and hook option types exported by `@amap-vue/hooks`.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/tile-layer.md
+++ b/docs/components/tile-layer.md
@@ -1,0 +1,112 @@
+# `<AmapTileLayer>` & friends
+
+`<AmapTileLayer>` wraps the JSAPI tile layer so you can stack additional imagery on top of the base map. It also powers the convenience components `<AmapTrafficLayer>`, `<AmapRoadNetLayer>`, and `<AmapSatelliteLayer>`.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `visible` | `boolean` | `true` | Controls whether the layer is added to the map. |
+| `opacity` | `number \| undefined` | – | Blends the layer against the base map. |
+| `zIndex` | `number \| undefined` | – | Rendering order between layers. |
+| `tileUrl` | `string \| ((x: number, y: number, level: number) => string)` | – | Custom tile URL template. Mutually exclusive with `getTileUrl`. |
+| `getTileUrl` | `(x: number, y: number, level: number) => string` | – | Imperative URL resolver. |
+| `options` | `Partial<AMap.TileLayerOptions>` | `{}` | Additional JSAPI options such as `zooms` or `tileSize`. Forward variant-specific values (like traffic refresh intervals) via each component's dedicated `options` prop. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.TileLayer` | Fires once the layer instance is created and added to the map. |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const showTraffic = ref(true)
+const showRoadNet = ref(false)
+const showSatellite = ref(false)
+</script>
+
+<template>
+  <AmapMap :center="[116.397, 39.908]" :zoom="11" class="map-shell">
+    <AmapTrafficLayer v-if="showTraffic" auto-refresh />
+    <AmapRoadNetLayer v-if="showRoadNet" />
+    <AmapSatelliteLayer v-if="showSatellite" />
+  </AmapMap>
+</template>
+```
+
+Toggle the reactive flags to add or remove each overlay. The components automatically dispose their instances when unmounted.
+
+<ClientOnly>
+  <TileLayerDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import TileLayerDemo from '../examples/TileLayerDemo.vue'
+</script>
+
+### Variants
+
+- **`<AmapTrafficLayer>`** – renders live congestion information. Use the `auto-refresh` and `interval` props for periodic updates.
+- **`<AmapRoadNetLayer>`** – displays road grid lines on top of the base map. Useful when the underlying theme omits boundaries.
+- **`<AmapSatelliteLayer>`** – swaps the imagery tiles to satellite photos while keeping vector overlays intact.
+
+All variants accept the shared `visible`, `opacity`, `zIndex`, and `options` props. Their `ready` event emits the concrete JSAPI layer (`AMap.TileLayer.Traffic`, `AMap.TileLayer.RoadNet`, etc.).
+
+### Custom sources
+
+Provide a `tileUrl` template to connect to custom raster services:
+
+```vue
+<AmapTileLayer
+  tile-url="https://webrd0{s}.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=6&x=[x]&y=[y]&z=[z]"
+  :options="{ detectRetina: true }"
+/>
+```
+
+When the URL depends on complex logic (authentication headers, signed URLs) prefer the `getTileUrl` callback instead.
+
+### TypeScript signature
+
+```ts
+export interface TileLayerProps {
+  visible?: boolean
+  opacity?: number
+  zIndex?: number
+  tileUrl?: string | ((x: number, y: number, level: number) => string)
+  getTileUrl?: (x: number, y: number, level: number) => string
+  options?: Partial<AMap.TileLayerOptions>
+}
+
+export interface TrafficLayerProps extends TileLayerProps {
+  autoRefresh?: boolean
+  interval?: number
+  options?: Partial<AMap.TileLayer.Traffic.Options>
+}
+
+export interface RoadNetLayerProps extends TileLayerProps {
+  options?: Partial<AMap.TileLayerOptions>
+}
+
+export interface SatelliteLayerProps extends TileLayerProps {
+  options?: Partial<AMap.TileLayerOptions>
+}
+
+type TileLayerReadyPayload = AMap.TileLayer | AMap.TileLayer.Traffic | AMap.TileLayer.RoadNet | AMap.TileLayer.Satellite
+```
+
+The prop interfaces and ready payload types mirror the component exports and reuse hook typings from `@amap-vue/hooks`.
+
+### Common pitfalls
+
+- Ensure `<AmapTileLayer>` (and its variants) live inside `<AmapMap>` so they can access the injected map context.
+- Do not configure conflicting loaders per map. Call `loader.config` once to share plugin configuration.
+- `auto-refresh` triggers network requests every few seconds; disable it when the layer is outside the viewport to conserve quota.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/examples/ControlsDemo.vue
+++ b/docs/examples/ControlsDemo.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, ref } from 'vue'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const zoom = 12
+const hasKey = computed(() => Boolean(key))
+
+const showToolBar = ref(true)
+const showScale = ref(true)
+const showControlBar = ref(false)
+const showMapType = ref(true)
+const controlPosition = ref<'LT' | 'RT' | 'LB' | 'RB'>('RT')
+const mapTypeDefaultType = ref<0 | 1>(0)
+const mapTypeShowTraffic = ref(false)
+const mapTypeShowRoad = ref(true)
+const showZoomBar = ref(true)
+const showControlButton = ref(true)
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to see the live demo.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="zoom">
+          <AmapToolBar
+            v-if="showToolBar"
+            :position="controlPosition"
+            :offset="[16, 16]"
+          />
+          <AmapScale
+            v-if="showScale"
+            :position="controlPosition"
+            :offset="[16, 86]"
+          />
+          <AmapControlBar
+            v-if="showControlBar"
+            :position="controlPosition"
+            :show-zoom-bar="showZoomBar"
+            :show-control-button="showControlButton"
+          />
+          <AmapMapType
+            v-if="showMapType"
+            :position="controlPosition"
+            :offset="[16, 156]"
+            :default-type="mapTypeDefaultType"
+            :show-traffic="mapTypeShowTraffic"
+            :show-road="mapTypeShowRoad"
+          />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          <input v-model="showToolBar" type="checkbox">
+          ToolBar
+        </label>
+        <label>
+          <input v-model="showScale" type="checkbox">
+          Scale
+        </label>
+        <label>
+          <input v-model="showControlBar" type="checkbox">
+          ControlBar
+        </label>
+        <label>
+          <input v-model="showMapType" type="checkbox">
+          MapType
+        </label>
+        <label>
+          Position
+          <select v-model="controlPosition">
+            <option value="LT">Left · Top</option>
+            <option value="RT">Right · Top</option>
+            <option value="LB">Left · Bottom</option>
+            <option value="RB">Right · Bottom</option>
+          </select>
+        </label>
+        <template v-if="showControlBar">
+          <label>
+            <input v-model="showZoomBar" type="checkbox">
+            Zoom bar
+          </label>
+          <label>
+            <input v-model="showControlButton" type="checkbox">
+            Rotate/tilt button
+          </label>
+        </template>
+        <template v-if="showMapType">
+          <label>
+            Default layer
+            <select v-model.number="mapTypeDefaultType">
+              <option :value="0">Standard</option>
+              <option :value="1">Satellite</option>
+            </select>
+          </label>
+          <label>
+            <input v-model="mapTypeShowTraffic" type="checkbox">
+            Toggle traffic
+          </label>
+          <label>
+            <input v-model="mapTypeShowRoad" type="checkbox">
+            Toggle road net
+          </label>
+        </template>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/examples/TileLayerDemo.vue
+++ b/docs/examples/TileLayerDemo.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, ref } from 'vue'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const zoom = 11
+const showTraffic = ref(true)
+const showRoadNet = ref(false)
+const showSatellite = ref(false)
+const hasKey = computed(() => Boolean(key))
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to see the live demo.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="zoom">
+          <AmapTrafficLayer v-if="showTraffic" auto-refresh />
+          <AmapRoadNetLayer v-if="showRoadNet" />
+          <AmapSatelliteLayer v-if="showSatellite" />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          <input v-model="showTraffic" type="checkbox">
+          Traffic
+        </label>
+        <label>
+          <input v-model="showRoadNet" type="checkbox">
+          Road net
+        </label>
+        <label>
+          <input v-model="showSatellite" type="checkbox">
+          Satellite
+        </label>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/hooks/use-tile-layer.md
+++ b/docs/hooks/use-tile-layer.md
@@ -1,0 +1,133 @@
+# `useTileLayer`, `useTrafficLayer`, `useRoadNetLayer`, `useSatelliteLayer`
+
+The tile layer hooks wrap the JSAPI tile overlays so you can imperatively toggle imagery, traffic, and vector road grids from the Composition API.
+
+## Basic usage
+
+```ts
+import { useMap, useTileLayer, useTrafficLayer } from '@amap-vue/hooks'
+import { ref } from 'vue'
+
+const container = ref<HTMLDivElement | null>(null)
+
+const { map, ready } = useMap(() => ({
+  container,
+  center: [116.397, 39.908],
+  zoom: 11,
+}))
+
+const baseLayer = useTileLayer(() => map.value, {
+  tileUrl: 'https://your.tiles/{z}/{x}/{y}.png',
+  opacity: 0.8,
+})
+
+const traffic = useTrafficLayer(() => map.value, {
+  visible: false,
+  autoRefresh: true,
+  interval: 120,
+})
+
+ready(() => {
+  traffic.show()
+})
+
+// Later in your component you can hide/show layers reactively
+baseLayer.setOpacity(0.6)
+traffic.hide()
+```
+
+The hook defers instantiation until both the map instance and JSAPI script are available. Specialized hooks automatically request the necessary plugins (`AMap.TileLayer.Traffic`, `AMap.TileLayer.Satellite`, etc.).
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `visible` | `boolean \| undefined` | `true` | Initial visibility of the layer. |
+| `opacity` | `number \| undefined` | – | Blend value between `0` (transparent) and `1` (opaque). |
+| `zIndex` | `number \| undefined` | – | Rendering order relative to other overlays. |
+| `tileUrl` | `string \| ((x: number, y: number, level: number) => string) \| undefined` | – | URL template or resolver for custom sources. |
+| `getTileUrl` | `(x: number, y: number, level: number) => string \| undefined` | – | Alternative callback for dynamic URLs. Ignored when `tileUrl` is provided. |
+| `options` | `Partial<AMap.TileLayerOptions>` | `{}` | Pass through any additional JSAPI options (`zooms`, `detectRetina`, etc.). |
+
+`useTrafficLayer` extends the base options with `autoRefresh`, `interval`, and `options: Partial<AMap.TileLayer.Traffic.Options>`. `useSatelliteLayer` and `useRoadNetLayer` accept the same options as `useTileLayer`.
+
+## Return value
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `overlay` | `ShallowRef<AMap.TileLayer \| null>` | Reactive reference to the layer instance. Each variant narrows this type. |
+| `show` / `hide` | `() => void` | Toggle the layer without destroying it. |
+| `reload` | `() => void` | Force the JSAPI to refetch tiles (available on standard layers). |
+| `setOpacity` | `(opacity: number \| undefined) => void` | Update the opacity in place. |
+| `setZIndex` | `(zIndex: number \| undefined) => void` | Adjust rendering order. |
+| `setTileUrl` | `(url: string \| ((x: number, y: number, level: number) => string) \| undefined) => void` | Switch the tile source on the fly. |
+| `setOptions` | `(options: Partial<AMap.TileLayerOptions>) => void` | Forward updates to the underlying instance. |
+| `on` / `off` | `(event: string, handler: (event: any) => void)` | Subscribe to and unsubscribe from JSAPI events. |
+| `destroy` | `() => void` | Remove the layer from the map and clean up listeners. |
+
+## Variants
+
+- **`useTrafficLayer`** – Enables congestion overlays. Combine with `autoRefresh` and `interval` to pull fresh data on a schedule.
+- **`useRoadNetLayer`** – Draws road boundaries above themed base maps. Useful when the base style removes outlines.
+- **`useSatelliteLayer`** – Switches to satellite imagery tiles while keeping vector overlays intact.
+
+Each variant returns the same API surface while narrowing `overlay.value` to the concrete JSAPI class.
+
+## TypeScript signature
+
+```ts
+import type { OverlayLifecycle } from '@amap-vue/hooks'
+import type { MaybeRefOrGetter } from 'vue'
+
+export interface UseTileLayerOptions extends Partial<AMap.TileLayerOptions> {
+  visible?: boolean
+}
+
+export interface UseTileLayerReturn<TLayer extends AMap.TileLayer = AMap.TileLayer>
+  extends OverlayLifecycle<TLayer> {
+  show: () => void
+  hide: () => void
+  reload: () => void
+  setOpacity: (opacity: number | undefined) => void
+  setZIndex: (zIndex: number | undefined) => void
+  setTileUrl: (
+    url: string | ((x: number, y: number, level: number) => string) | undefined
+  ) => void
+  setOptions: (options: Partial<AMap.TileLayerOptions>) => void
+}
+
+export interface UseTrafficLayerOptions
+  extends UseTileLayerOptions, Partial<AMap.TileLayer.Traffic.Options> {}
+
+export function useTileLayer(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<UseTileLayerOptions>,
+): UseTileLayerReturn
+
+export function useTrafficLayer(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<UseTrafficLayerOptions>,
+): UseTileLayerReturn<AMap.TileLayer.Traffic>
+
+export function useSatelliteLayer(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<UseTileLayerOptions>,
+): UseTileLayerReturn<AMap.TileLayer.Satellite>
+
+export function useRoadNetLayer(
+  mapRef: MaybeRefOrGetter<AMap.Map | null | undefined>,
+  options: MaybeRefOrGetter<UseTileLayerOptions>,
+): UseTileLayerReturn<AMap.TileLayer.RoadNet>
+```
+
+All types shown above are re-exported from `@amap-vue/hooks`, while `AMap.*` types come from the JSAPI ambient declarations.
+
+## Common pitfalls
+
+- Always pass a map reference (`() => map.value`) instead of the raw map to guard against SSR and deferred mount.
+- Avoid calling both `tileUrl` and `getTileUrl`; the hook prioritizes `getTileUrl` only when `tileUrl` is undefined.
+- Traffic layers poll the network when `autoRefresh` is enabled—pause it when the view is hidden to reduce quota usage.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/todo.md
+++ b/todo.md
@@ -286,9 +286,12 @@ amap-vue-kit/
 * [x] 初始化 `docs`（暗黑模式、侧边栏、DocSearch 预留）
 * [ ] 侧边栏结构
 
-  * [ ] Getting Started（安装、Key、最小示例、容器尺寸、常见报错）
+  * [x] Getting Started（安装、Key、最小示例、容器尺寸、常见报错）
   * [ ] Components（按 A/B/C/D 分组）
-  * [ ] Hooks（与组件一一对应）
+    * [x] B 组：TileLayer + 子层文档初稿
+    * [x] C 组：地图控件（ToolBar/Scale/ControlBar/MapType）
+* [ ] Hooks（与组件一一对应）
+  * [x] TileLayer / Traffic / RoadNet / Satellite hooks 文档
   * [ ] Advanced（大数据点/性能、ImageLayer、轨迹动画、主题样式）
   * [ ] Recipes（园区底图、聚合、信息窗联动）
   * [ ] FAQ（Key、CSP、地图不显示排错）


### PR DESCRIPTION
## Summary
- add a tile layer hook guide that explains useTileLayer/useTrafficLayer/useRoadNetLayer/useSatelliteLayer APIs and variants
- document TypeScript signatures for the map control and tile layer components and note the shared option types
- surface the new hook in the VitePress sidebar and mark the documentation milestone progress in the project TODO

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d003d0da0c83308c37e8cabff00da6