### PR TITLE
docs: add labels and heat map guides

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
           text: 'B · Layers',
           items: [
             { text: 'Tile Layers', link: '/components/tile-layer' },
+            { text: 'Labels Layer', link: '/components/labels-layer' },
+            { text: 'Label Marker', link: '/components/label-marker' },
+            { text: 'Heat Map', link: '/components/heat-map' },
           ],
         },
         {
@@ -67,6 +70,9 @@ export default defineConfig({
             { text: 'useCircle', link: '/hooks/use-circle' },
             { text: 'useTileLayer', link: '/hooks/use-tile-layer' },
             { text: 'useOverlay', link: '/hooks/use-overlay' },
+            { text: 'useLabelsLayer', link: '/hooks/use-labels-layer' },
+            { text: 'useLabelMarker', link: '/hooks/use-label-marker' },
+            { text: 'useHeatMap', link: '/hooks/use-heat-map' },
           ],
         },
       ],

--- a/docs/components/heat-map.md
+++ b/docs/components/heat-map.md
@@ -1,0 +1,65 @@
+# `<AmapHeatMap>`
+
+Visualise density-based metrics using the JSAPI heat map plugin. The component keeps the dataset in sync with Vue state and
+exposes helpers to push incremental updates.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `data` | `AMap.HeatMapDataPoint[]` | `[]` | Collection of points with `lng`, `lat`, and `count`. |
+| `max` | `number \| undefined` | – | Optional maximum value used to normalise the gradient. |
+| `radius` | `number \| undefined` | – | Radius of influence for each point (in pixels). |
+| `gradient` | `Record<string, string> \| undefined` | – | Custom colour stops mapping ratios (`'0.5'`) to CSS colours. |
+| `opacity` | `[number, number] \| undefined` | – | Min/max opacity bounds passed to the JSAPI plugin. |
+| `visible` | `boolean` | `true` | Toggle the heat map without destroying it. |
+| `options` | `Partial<AMap.HeatMapOptions>` | `{}` | Additional JSAPI options such as `zoomFactor` or `unit`. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.HeatMap` | Emitted when the plugin instance is created. |
+
+## Usage
+
+```vue
+<AmapMap :center="[116.397, 39.908]" :zoom="12" class="map-shell">
+  <AmapHeatMap :data="points" :radius="32" :gradient="gradient" />
+</AmapMap>
+```
+
+The component requests the `AMap.HeatMap` plugin on demand and automatically reapplies options when `data`, `radius`, or the grad
+ient change.
+
+<ClientOnly>
+  <HeatMapDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import HeatMapDemo from '../examples/HeatMapDemo.vue'
+</script>
+
+### TypeScript signature
+
+```ts
+export interface HeatMapProps {
+  data?: AMap.HeatMapDataPoint[]
+  max?: number
+  radius?: number
+  gradient?: Record<string, string>
+  opacity?: [number, number]
+  visible?: boolean
+  options?: Partial<AMap.HeatMapOptions>
+}
+```
+
+### Common pitfalls
+
+- Large datasets benefit from pre-aggregating values on the server to reduce payload size.
+- The heat map uses pixel radii. Increase the radius at low zoom levels to avoid sparse visuals.
+- When mixing heat maps with other WebGL overlays, prefer the same `zIndex` ordering to avoid flickering artefacts.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/label-marker.md
+++ b/docs/components/label-marker.md
@@ -1,0 +1,82 @@
+# `<AmapLabelMarker>`
+
+Attach high-performance text or icon markers to an `<AmapLabelsLayer>`. The component proxies `LabelMarker` options and expose
+s events so you can respond to clicks and hovers just like standard markers.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `position` | `LngLatLike \| undefined` | Coordinates of the marker. Accepts `[lng, lat]` tuples or `AMap.LngLat`. |
+| `text` | `AMap.LabelMarkerTextOptions \| undefined` | Rich text content rendered by the JSAPI. Supports offsets, styles, and multiple lines. |
+| `icon` | `AMap.LabelMarkerIconOptions \| undefined` | Optional image sprite displayed beneath or alongside the text. |
+| `zooms` | `[number, number] \| undefined` | Zoom range in which the marker remains visible. |
+| `opacity` | `number \| undefined` | Alpha transparency for the marker. |
+| `zIndex` | `number \| undefined` | Rendering order relative to other label markers. |
+| `extData` | `any` | Arbitrary metadata stored on the marker instance. |
+| `visible` | `boolean \| undefined` | Control visibility without destroying the marker. |
+| `collision` | `boolean \| undefined` | Override the parent layer's collision behaviour for this marker. |
+| `options` | `Partial<AMap.LabelMarkerOptions>` | Additional JSAPI options merged during creation. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.LabelMarker` | Emitted when the marker instance becomes available. |
+| `click` | `any` | Click events forwarded from the JSAPI instance. |
+| `mouseover` | `any` | Pointer enter events. |
+| `mouseout` | `any` | Pointer leave events. |
+
+## Usage
+
+```vue
+<AmapLabelsLayer :collision="true">
+  <AmapLabelMarker
+    v-for="item in data"
+    :key="item.id"
+    :position="item.position"
+    :text="item.text"
+    :icon="item.icon"
+    @click="handleSelect(item)"
+  />
+</AmapLabelsLayer>
+```
+
+Place label markers inside a labels layer so they can share GPU resources. The component exposes the underlying instance via `r
+eady` and through `template ref`/`expose` so you can call imperative methods when necessary.
+
+<ClientOnly>
+  <LabelsLayerDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import LabelsLayerDemo from '../examples/LabelsLayerDemo.vue'
+</script>
+
+### TypeScript signature
+
+```ts
+export interface LabelMarkerProps {
+  position?: LngLatLike
+  text?: AMap.LabelMarkerTextOptions
+  icon?: AMap.LabelMarkerIconOptions
+  zooms?: [number, number]
+  opacity?: number
+  zIndex?: number
+  extData?: any
+  visible?: boolean
+  collision?: boolean
+  options?: Partial<AMap.LabelMarkerOptions>
+}
+```
+
+### Common pitfalls
+
+- Label markers must live inside `<AmapLabelsLayer>`; otherwise the component warns during development.
+- When providing `text.offset`, you can use `[x, y]` tuples. The component converts them to `AMap.Pixel` internally.
+- Collision behaviour depends on the parent layer. Set both the layer's `collision` prop and the marker's `collision` override
+when you need granular control.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/labels-layer.md
+++ b/docs/components/labels-layer.md
@@ -1,0 +1,78 @@
+# `<AmapLabelsLayer>`
+
+Render hundreds of rich text markers with GPU-accelerated performance. The labels layer batches all `LabelMarker` instances and
+handles collision detection so the map remains responsive even with dense datasets.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `visible` | `boolean` | `true` | Toggles whether the layer is displayed on the map. |
+| `opacity` | `number \| undefined` | – | Blend the layer against the base map. |
+| `zIndex` | `number \| undefined` | – | Rendering order when stacking multiple layers. |
+| `zooms` | `[number, number] \| undefined` | – | Minimum and maximum zoom levels that keep the layer visible. |
+| `collision` | `boolean \| undefined` | – | Enable JSAPI collision avoidance between label markers. |
+| `allowCollision` | `boolean \| undefined` | – | Force labels to overlap even when collisions are detected. |
+| `options` | `Partial<AMap.LabelsLayerOptions>` | `{}` | Extra JSAPI options forwarded to the underlying layer. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.LabelsLayer` | Fired once the layer instance is created and attached to the map. |
+
+## Usage
+
+```vue
+<AmapMap :center="[116.397, 39.908]" :zoom="13" class="map-shell">
+  <AmapLabelsLayer :collision="true">
+    <AmapLabelMarker
+      v-for="office in offices"
+      :key="office.id"
+      :position="office.position"
+      :text="{
+        content: office.name,
+        direction: 'top',
+        offset: [0, -12]
+      }"
+    />
+  </AmapLabelsLayer>
+</AmapMap>
+```
+
+Use the `visible` and `collision` props to toggle visibility and overlap rules without recreating the layer. Individual label ma
+rkers can also control their own visibility using the `visible` prop.
+
+<ClientOnly>
+  <LabelsLayerDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import LabelsLayerDemo from '../examples/LabelsLayerDemo.vue'
+</script>
+
+### TypeScript signature
+
+```ts
+export interface LabelsLayerProps {
+  visible?: boolean
+  opacity?: number
+  zIndex?: number
+  zooms?: [number, number]
+  collision?: boolean
+  allowCollision?: boolean
+  options?: Partial<AMap.LabelsLayerOptions>
+}
+```
+
+### Common pitfalls
+
+- Mount `<AmapLabelsLayer>` inside `<AmapMap>` so the injected map instance is available.
+- Collision detection only applies to label markers inside the same layer. Create separate layers when combining different data
+sets.
+- Remember to configure the AMap loader with the `AMap.LabelsLayer` plugin if you instantiate the layer manually. The component
+requests it automatically.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/examples/HeatMapDemo.vue
+++ b/docs/examples/HeatMapDemo.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, reactive, ref } from 'vue'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const hasKey = computed(() => Boolean(key))
+const showHeatMap = ref(true)
+const radius = ref(32)
+const gradientKey = ref<'sunset' | 'ocean' | 'default'>('sunset')
+
+const gradients = reactive<Record<'sunset' | 'ocean' | 'default', Record<string, string> | undefined>>({
+  sunset: {
+    '0.2': '#4c6ef5',
+    '0.5': '#ff922b',
+    '0.8': '#f03e3e',
+    '1.0': '#c2255c',
+  },
+  ocean: {
+    '0.2': '#64dfdf',
+    '0.5': '#48bfe3',
+    '0.8': '#5390d9',
+    '1.0': '#6930c3',
+  },
+  default: undefined,
+})
+
+const gradient = computed(() => gradients[gradientKey.value])
+
+const points: AMap.HeatMapDataPoint[] = [
+  { lng: 116.397, lat: 39.908, count: 90 },
+  { lng: 116.388, lat: 39.913, count: 55 },
+  { lng: 116.406, lat: 39.92, count: 65 },
+  { lng: 116.4, lat: 39.903, count: 40 },
+  { lng: 116.409, lat: 39.905, count: 80 },
+  { lng: 116.393, lat: 39.917, count: 50 },
+]
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to see the live demo.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="12">
+          <AmapHeatMap
+            v-if="showHeatMap"
+            :data="points"
+            :radius="radius"
+            :gradient="gradient"
+          />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          <input v-model="showHeatMap" type="checkbox">
+          Show heat map
+        </label>
+        <label>
+          Radius
+          <select v-model.number="radius">
+            <option :value="28">28 px</option>
+            <option :value="32">32 px</option>
+            <option :value="40">40 px</option>
+          </select>
+        </label>
+        <label>
+          Gradient
+          <select v-model="gradientKey">
+            <option value="sunset">Sunset</option>
+            <option value="ocean">Ocean</option>
+            <option value="default">Default</option>
+          </select>
+        </label>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/examples/LabelsLayerDemo.vue
+++ b/docs/examples/LabelsLayerDemo.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, reactive, ref } from 'vue'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const hasKey = computed(() => Boolean(key))
+const showLayer = ref(true)
+const avoidCollision = ref(true)
+
+const points = reactive([
+  {
+    id: 1,
+    position: [116.397, 39.908] as [number, number],
+    label: 'Tiananmen',
+  },
+  {
+    id: 2,
+    position: [116.4065, 39.9147] as [number, number],
+    label: 'National Museum',
+  },
+  {
+    id: 3,
+    position: [116.4036, 39.9163] as [number, number],
+    label: 'Forbidden City',
+  },
+  {
+    id: 4,
+    position: [116.3883, 39.9131] as [number, number],
+    label: 'Great Hall',
+  },
+])
+
+function textOptions(label: string): AMap.LabelMarkerTextOptions {
+  return {
+    content: label,
+    direction: 'top',
+    offset: [0, -12],
+    style: {
+      fontSize: 12,
+      fillColor: '#111827',
+      strokeColor: '#ffffff',
+      strokeWidth: 2,
+      padding: [2, 6],
+      backgroundColor: 'rgba(255,255,255,0.9)',
+      borderRadius: 4,
+    },
+  }
+}
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to see the live demo.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="13">
+          <AmapLabelsLayer :visible="showLayer" :collision="avoidCollision">
+            <AmapLabelMarker
+              v-for="point in points"
+              :key="point.id"
+              :position="point.position"
+              :text="textOptions(point.label)"
+            />
+          </AmapLabelsLayer>
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          <input v-model="showLayer" type="checkbox">
+          Show labels
+        </label>
+        <label>
+          <input v-model="avoidCollision" type="checkbox">
+          Collision avoidance
+        </label>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/hooks/use-heat-map.md
+++ b/docs/hooks/use-heat-map.md
@@ -1,0 +1,37 @@
+# `useHeatMap`
+
+Drive the heat map plugin from Composition API code. The hook defers instantiation until both the JSAPI and the map are ready,
+then synchronises the dataset whenever the reactive options change.
+
+```ts
+import { useHeatMap } from '@amap-vue/hooks'
+
+const heatMap = useHeatMap(() => map.value, () => ({
+  data: points.value,
+  radius: 32,
+  gradient: gradients.sunset,
+}))
+
+watch(points, (next) => {
+  heatMap.setDataSet({ data: next, max: 120 })
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.HeatMap \| null>` referencing the heat map instance. |
+| `ready` | Register callbacks triggered when the plugin has been created. |
+| `setOptions` | Update plugin options such as `radius`, `opacity`, or `gradient`. |
+| `setDataSet` | Replace the full dataset (`{ data, max }`). The hook caches the latest values. |
+| `addDataPoint` | Append a single point without rebuilding the dataset. |
+| `show` / `hide` | Toggle visibility imperatively. |
+| `destroy` | Dispose of the heat map and release references. |
+
+### Notes
+
+- The hook requests the `AMap.HeatMap` plugin automatically; no need to preload it via `loader.config`.
+- The `data` option is watched deeply. Pushing to the reactive array triggers incremental updates without recreating the instanc
+e.
+- When the map reference becomes `null`, the heat map detaches itself and waits for a new map instance before reattaching.

--- a/docs/hooks/use-label-marker.md
+++ b/docs/hooks/use-label-marker.md
@@ -1,0 +1,42 @@
+# `useLabelMarker`
+
+Create high-performance label markers in Composition API code. The composable shares the same lifecycle guarantees as the compo
+nent: markers are lazily created once the layer is ready, listeners are rebound after option changes, and everything is cleaned
+up on unmount.
+
+```ts
+import { useLabelMarker, useLabelsLayer } from '@amap-vue/hooks'
+
+const layer = useLabelsLayer(() => map.value, () => ({ collision: true }))
+
+layer.ready((instance) => {
+  const marker = useLabelMarker(() => instance, () => ({
+    position: [116.397, 39.908],
+    text: { content: 'HQ', direction: 'top' },
+  }))
+
+  marker.on('click', () => console.log('label clicked'))
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `marker` | `ShallowRef<AMap.LabelMarker \| null>` referencing the marker instance. |
+| `setPosition` | Update the marker position with `LngLatLike` data. |
+| `setText` | Apply text configuration including offsets and styles. |
+| `setIcon` | Change the icon sprite. |
+| `setZooms` | Restrict the zoom range. |
+| `setOpacity` / `setZIndex` | Adjust visual properties without recreating the marker. |
+| `setExtData` | Attach arbitrary metadata. |
+| `show` / `hide` | Toggle visibility imperatively. |
+| `on` / `off` | Subscribe to and unsubscribe from marker events. |
+| `destroy` | Remove the marker from its parent layer and tear down listeners. |
+
+### Notes
+
+- The composable automatically reattaches the marker if the labels layer instance changes.
+- `text.offset` accepts tuples such as `[0, -12]`; they are converted to `AMap.Pixel` behind the scenes when the JSAPI is availa
+ble.
+- When the supplied layer reference is `null`, the marker detaches itself and waits until a layer becomes available again.

--- a/docs/hooks/use-labels-layer.md
+++ b/docs/hooks/use-labels-layer.md
@@ -1,0 +1,42 @@
+# `useLabelsLayer`
+
+Imperatively manage the JSAPI `LabelsLayer` while keeping Vue reactivity. The composable lazy-loads the `AMap.LabelsLayer` plugi
+n, attaches the layer to the provided map, and updates visibility/opacities when the reactive options change.
+
+```ts
+import { useLabelMarker, useLabelsLayer } from '@amap-vue/hooks'
+import { ref } from 'vue'
+
+const markers = ref(points)
+const labelsLayer = useLabelsLayer(() => map.value, () => ({
+  visible: true,
+  zooms: [10, 20],
+  collision: true,
+}))
+
+labelsLayer.ready((layer) => {
+  markers.value.forEach((item) => {
+    useLabelMarker(() => layer, { position: item.position, text: item.text })
+  })
+})
+```
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.LabelsLayer \| null>` pointing to the layer instance. |
+| `ready` | Register callbacks executed once the layer is available. |
+| `setOptions` | Call through to `layer.setOptions()` for incremental updates. |
+| `setOpacity` / `setZIndex` | Adjust style attributes without recreating the layer. |
+| `show` / `hide` | Toggle visibility. Also triggered when the reactive `visible` option changes. |
+| `add` / `remove` | Attach or detach one or many `LabelMarker` instances. |
+| `clear` | Remove every registered marker from the layer. |
+| `destroy` | Dispose of the layer and detach it from the map. |
+
+### Notes
+
+- The composable watches the reactive options deeply, so `collision`, `visible`, and `opacity` update automatically.
+- When the map reference becomes `null`, the layer detaches itself and reattaches once a map is available again.
+- Use the higher-level `<AmapLabelsLayer>` component when authoring templates; `useLabelsLayer` is ideal for custom renderers or
+server-driven setups.


### PR DESCRIPTION
## Summary
- add component guides for `<AmapLabelsLayer>`, `<AmapLabelMarker>`, and `<AmapHeatMap>` complete with live demos
- document `useLabelsLayer`, `useLabelMarker`, and `useHeatMap` composables to match the new component surface area
- update the VitePress sidebar so the new component and hook pages are discoverable

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d02a27afd88330a5773bbc9c279ec0