### PR TITLE
docs: cover overlay utilities and hooks

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -57,6 +57,14 @@ export default defineConfig({
             { text: 'Map Controls', link: '/components/map-controls' },
           ],
         },
+        {
+          text: 'D · Utilities & Editors',
+          items: [
+            { text: 'Image Layer', link: '/components/image-layer' },
+            { text: 'Overlay Group', link: '/components/overlay-group' },
+            { text: 'Shape Editors', link: '/components/editors' },
+          ],
+        },
       ],
       '/hooks/': [
         {
@@ -69,10 +77,15 @@ export default defineConfig({
             { text: 'usePolygon', link: '/hooks/use-polygon' },
             { text: 'useCircle', link: '/hooks/use-circle' },
             { text: 'useTileLayer', link: '/hooks/use-tile-layer' },
+            { text: 'useImageLayer', link: '/hooks/use-image-layer' },
+            { text: 'useHeatMap', link: '/hooks/use-heat-map' },
             { text: 'useOverlay', link: '/hooks/use-overlay' },
+            { text: 'useOverlayGroup', link: '/hooks/use-overlay-group' },
             { text: 'useLabelsLayer', link: '/hooks/use-labels-layer' },
             { text: 'useLabelMarker', link: '/hooks/use-label-marker' },
-            { text: 'useHeatMap', link: '/hooks/use-heat-map' },
+            { text: 'useMassMarkers', link: '/hooks/use-mass-markers' },
+            { text: 'useControl', link: '/hooks/use-control' },
+            { text: 'useEditor', link: '/hooks/use-editor' },
           ],
         },
       ],

--- a/docs/components/editors.md
+++ b/docs/components/editors.md
@@ -1,0 +1,122 @@
+# `<AmapCircleEditor>`, `<AmapRectangleEditor>`, `<AmapEllipseEditor>`
+
+Enable interactive geometry editing without hand-rolling plugin wiring. These lightweight components wrap their respective JSAPI editors and sync the `active` state and target overlay reactively.
+
+## Shared props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `target` | `AMap.Circle \| AMap.Rectangle \| AMap.Ellipse \| string \| null \| undefined` | – | Overlay instance (or identifier) to edit. Strings resolve against `overlay.getId()` or `overlay.getExtData().id`. |
+| `active` | `boolean` | `false` | Whether the editor should be open. Toggle reactively to start/stop editing. |
+| `options` | `Partial<AMap.CircleEditorOptions \| AMap.RectangleEditorOptions \| AMap.EllipseEditorOptions>` | `{}` | Extra plugin options forwarded on creation. Each component narrows this union to the right type. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.CircleEditor \| AMap.RectangleEditor \| AMap.EllipseEditor` | Fired once the editor instance is instantiated. |
+| `adjust` | `any` | Mirrors the JSAPI `adjust` event emitted while dragging control points. |
+| `end` | `any` | Emitted after editing finishes (`mouseup`). |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { onBeforeUnmount, ref, shallowRef } from 'vue'
+
+const circleEditing = ref(false)
+const rectangleEditing = ref(false)
+const ellipseEditing = ref(false)
+const map = shallowRef<AMap.Map | null>(null)
+const rectangle = shallowRef<AMap.Rectangle | null>(null)
+const ellipse = shallowRef<AMap.Ellipse | null>(null)
+
+async function handleReady(instance: AMap.Map) {
+  map.value = instance
+  const AMap = await loader.load()
+  const rect = new AMap.Rectangle({
+    bounds: new AMap.Bounds([116.36, 39.9], [116.41, 39.94]),
+    strokeColor: '#20c997',
+    fillColor: 'rgba(32, 201, 151, 0.3)',
+    extData: { id: 'demo-rectangle' },
+  })
+  rect.setMap(instance)
+  rectangle.value = rect
+
+  const ell = new AMap.Ellipse({
+    center: [116.406, 39.912],
+    radius: [900, 420],
+    strokeColor: '#fd7e14',
+    fillColor: 'rgba(253, 126, 20, 0.25)',
+    extData: { id: 'demo-ellipse' },
+  })
+  ell.setMap(instance)
+  ellipse.value = ell
+}
+
+onBeforeUnmount(() => {
+  rectangle.value?.destroy?.()
+  ellipse.value?.destroy?.()
+})
+</script>
+
+<template>
+  <AmapMap :center="[116.397, 39.908]" :zoom="12" class="map-shell" @ready="handleReady">
+    <AmapCircle
+      :center="[116.397, 39.908]"
+      :radius="600"
+      :ext-data="{ id: 'demo-circle' }"
+      :options="{ strokeColor: '#4b8bff', fillColor: 'rgba(75, 139, 255, 0.2)' }"
+    />
+
+    <AmapCircleEditor target="demo-circle" :active="circleEditing" />
+    <AmapRectangleEditor :target="rectangle" :active="rectangleEditing" />
+    <AmapEllipseEditor target="demo-ellipse" :active="ellipseEditing" />
+  </AmapMap>
+</template>
+```
+
+Use the controls in the live demo to toggle each editor, switch between string identifiers and direct overlay references, and listen to the emitted `adjust`/`end` events.
+
+<ClientOnly>
+  <ShapeEditorsDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import ShapeEditorsDemo from '../examples/ShapeEditorsDemo.vue'
+</script>
+
+### TypeScript signature
+
+```ts
+export interface CircleEditorProps {
+  target?: AMap.Circle | string | null
+  active?: boolean
+  options?: Partial<AMap.CircleEditorOptions>
+}
+
+export interface RectangleEditorProps {
+  target?: AMap.Rectangle | string | null
+  active?: boolean
+  options?: Partial<AMap.RectangleEditorOptions>
+}
+
+export interface EllipseEditorProps {
+  target?: AMap.Ellipse | string | null
+  active?: boolean
+  options?: Partial<AMap.EllipseEditorOptions>
+}
+
+type EditorReadyPayload = AMap.CircleEditor | AMap.RectangleEditor | AMap.EllipseEditor
+```
+
+### Common pitfalls
+
+- Provide a stable way to resolve the target overlay—either pass the overlay instance directly or set `extData.id`/`id` so string lookups succeed.
+- Editors request their corresponding plugins (`AMap.CircleEditor`, etc.) lazily; make sure your loader key has permission to access them.
+- When destroying overlays manually, also set the editor `active` flag to `false` to avoid the plugin holding stale references.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/image-layer.md
+++ b/docs/components/image-layer.md
@@ -1,0 +1,81 @@
+# `<AmapImageLayer>`
+
+Project custom raster overlays (heat maps, floor plans, historical imagery) onto the map without writing imperative glue code. The component watches Vue state for URL, bounds, or opacity changes and keeps the underlying `AMap.ImageLayer` in sync.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `url` | `string` | – | Image URL to render. Required and reactive. |
+| `bounds` | `BoundsLike` | – | Geographic bounds of the image. Accepts `[southWest, northEast]` arrays or `AMap.Bounds`. |
+| `visible` | `boolean` | `true` | Toggles whether the layer is displayed on the map. |
+| `opacity` | `number \| undefined` | – | Blend the image with the base map (0 = transparent, 1 = opaque). |
+| `zIndex` | `number \| undefined` | – | Rendering order relative to other layers. |
+| `zooms` | `[number, number] \| undefined` | – | Minimum and maximum zoom levels that keep the layer visible. |
+| `options` | `Partial<AMap.ImageLayerOptions>` | `{}` | Extra JSAPI options forwarded to the image layer instance. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.ImageLayer` | Emitted once the image layer is created and attached to the map. |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const overlay = ref<'footprints' | 'satellite'>('footprints')
+const opacity = ref(0.75)
+const showOverlay = ref(true)
+</script>
+
+<template>
+  <AmapMap :center="[116.397, 39.908]" :zoom="12" class="map-shell">
+    <AmapImageLayer
+      :url="overlay === 'footprints' ? 'https://a.amap.com/jsapi_demos/static/demo-center-v2/overlay/overlay.png' : 'https://a.amap.com/jsapi_demos/static/demo-center-v2/overlay/overlay-heat.png'"
+      :bounds="overlay === 'footprints' ? [[116.357, 39.903], [116.412, 39.949]] : [[116.365, 39.897], [116.418, 39.946]]"
+      :opacity="opacity"
+      :visible="showOverlay"
+      :z-index="120"
+    />
+  </AmapMap>
+</template>
+```
+
+Switch the dropdown and slider in the example below to change imagery sources, adjust opacity, or temporarily hide the layer without destroying the instance.
+
+<ClientOnly>
+  <ImageLayerDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import ImageLayerDemo from '../examples/ImageLayerDemo.vue'
+</script>
+
+### TypeScript signature
+
+```ts
+export interface ImageLayerProps {
+  url: string
+  bounds: BoundsLike
+  visible?: boolean
+  opacity?: number
+  zIndex?: number
+  zooms?: [number, number]
+  options?: Partial<AMap.ImageLayerOptions>
+}
+
+type ImageLayerReadyPayload = AMap.ImageLayer
+```
+
+### Common pitfalls
+
+- `bounds` must describe the south-west and north-east corners. When using city-level images, double-check longitude/latitude order.
+- Keep the image URL HTTPS-accessible; browsers block insecure resources on secure origins.
+- If you need to swap multiple overlays frequently, reuse a single component instance and update the `url`/`bounds` props instead of re-mounting.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/components/overlay-group.md
+++ b/docs/components/overlay-group.md
@@ -1,0 +1,94 @@
+# `<AmapOverlayGroup>`
+
+Batch-manage large collections of overlays without juggling individual lifecycle hooks. The component wraps `AMap.OverlayGroup`,
+allowing you to swap datasets, hide or show the whole group, and call imperative helpers through `ref`.
+
+## Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `overlays` | `any[]` | `[]` | Array of JSAPI overlay instances to manage. Each item should be created with `new AMap.Marker(...)`, `new AMap.Circle(...)`, etc. |
+| `visible` | `boolean` | `true` | Show or hide the entire group without rebuilding its contents. |
+| `extData` | `any` | – | Arbitrary metadata forwarded to the underlying overlay group. |
+| `options` | `Record<string, any>` | `{}` | Additional options passed to the JSAPI constructor. |
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `ready` | `AMap.OverlayGroup` | Fired once the group instance is created and attached to the map. |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const overlays = ref<AMap.Marker[]>([])
+const showGroup = ref(true)
+const groupRef = ref<any>(null)
+
+function clearGroup() {
+  groupRef.value?.clearOverlays?.()
+}
+</script>
+
+<template>
+  <AmapMap :center="[116.397, 39.908]" :zoom="12" class="map-shell">
+    <AmapOverlayGroup ref="groupRef" :overlays="overlays" :visible="showGroup" />
+  </AmapMap>
+  <button type="button" @click="clearGroup">
+    Clear overlays
+  </button>
+</template>
+```
+
+Call the exposed methods on the component ref to mutate the group imperatively:
+
+```ts
+const api = groupRef.value
+api?.addOverlays(nextBatch)
+api?.clearOverlays()
+api?.hide()
+```
+
+<ClientOnly>
+  <OverlayGroupDemo />
+</ClientOnly>
+
+<script setup lang="ts">
+import OverlayGroupDemo from '../examples/OverlayGroupDemo.vue'
+</script>
+
+### Exposed helpers
+
+`<AmapOverlayGroup>` exposes the overlay group ref plus utility methods via `defineExpose`:
+
+- `group` – shallow ref of the underlying `AMap.OverlayGroup`.
+- `addOverlay(overlay)`, `addOverlays(overlays)` – append overlays in bulk.
+- `removeOverlay(overlay)`, `removeOverlays(overlays)` – detach overlays from the group.
+- `clearOverlays()` – remove every overlay managed by the group.
+- `getOverlays()` – snapshot of the current overlay list.
+
+### TypeScript signature
+
+```ts
+export interface OverlayGroupProps {
+  overlays?: any[]
+  visible?: boolean
+  extData?: any
+  options?: Record<string, any>
+}
+
+type OverlayGroupReadyPayload = AMap.OverlayGroup
+```
+
+### Common pitfalls
+
+- Overlays must be instantiated before passing them to the component. When swapping datasets, dispose of the previous array (e.g. call `setMap(null)` on markers) to avoid leaks.
+- The component does not render child content. Render interactive UIs elsewhere and mutate the `overlays` prop reactively.
+- If you need per-overlay reactivity, combine `<AmapOverlayGroup>` with watchers that rebuild the overlays array whenever your data changes.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/examples/ImageLayerDemo.vue
+++ b/docs/examples/ImageLayerDemo.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, ref } from 'vue'
+
+type OverlayKey = 'footprints' | 'heatmap'
+
+interface OverlaySource {
+  label: string
+  url: string
+  bounds: [[number, number], [number, number]]
+}
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const hasKey = computed(() => Boolean(key))
+const visible = ref(true)
+const opacity = ref(0.75)
+const activeSource = ref<OverlayKey>('footprints')
+
+const sources: Record<OverlayKey, OverlaySource> = {
+  footprints: {
+    label: 'Foot traffic heatmap',
+    url: 'https://a.amap.com/jsapi_demos/static/demo-center-v2/overlay/overlay.png',
+    bounds: [[116.357, 39.903], [116.412, 39.949]],
+  },
+  heatmap: {
+    label: 'Nighttime lights',
+    url: 'https://a.amap.com/jsapi_demos/static/demo-center-v2/overlay/overlay-heat.png',
+    bounds: [[116.365, 39.897], [116.418, 39.946]],
+  },
+}
+
+const source = computed(() => sources[activeSource.value])
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to preview the image layer overlay.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="12">
+          <AmapImageLayer
+            :url="source.url"
+            :bounds="source.bounds"
+            :opacity="opacity"
+            :visible="visible"
+            :z-index="130"
+          />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          Dataset
+          <select v-model="activeSource">
+            <option value="footprints">{{ sources.footprints.label }}</option>
+            <option value="heatmap">{{ sources.heatmap.label }}</option>
+          </select>
+        </label>
+        <label>
+          Opacity
+          <input v-model.number="opacity" type="range" min="0" max="1" step="0.05">
+          <span>{{ Math.round(opacity * 100) }}%</span>
+        </label>
+        <label>
+          <input v-model="visible" type="checkbox">
+          Visible
+        </label>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/examples/OverlayGroupDemo.vue
+++ b/docs/examples/OverlayGroupDemo.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
+
+type Category = 'coffee' | 'park'
+
+interface Place {
+  id: string
+  name: string
+  position: [number, number]
+  category: Category
+}
+
+interface FiltersState {
+  coffee: boolean
+  park: boolean
+}
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const center: [number, number] = [116.397, 39.908]
+const hasKey = computed(() => Boolean(key))
+const overlays = ref<AMap.Marker[]>([])
+const visible = ref(true)
+const filters = reactive<FiltersState>({ coffee: true, park: true })
+
+const places: Place[] = [
+  { id: 'coffee-1', name: 'Beijing Beans', position: [116.404, 39.915], category: 'coffee' },
+  { id: 'coffee-2', name: 'Chaoyang Coffee', position: [116.39, 39.92], category: 'coffee' },
+  { id: 'coffee-3', name: 'CBD Roasters', position: [116.456, 39.912], category: 'coffee' },
+  { id: 'park-1', name: 'Ritan Park', position: [116.45, 39.915], category: 'park' },
+  { id: 'park-2', name: 'Chaoyang Park', position: [116.48, 39.94], category: 'park' },
+  { id: 'park-3', name: 'Longtan Park', position: [116.435, 39.876], category: 'park' },
+]
+
+function disposeMarkers(markers: AMap.Marker[]) {
+  markers.forEach((marker) => {
+    marker.setMap?.(null)
+    marker.destroy?.()
+  })
+}
+
+async function rebuildOverlays() {
+  if (!key) {
+    disposeMarkers(overlays.value)
+    overlays.value = []
+    return
+  }
+
+  const AMap = await loader.load()
+  const next: AMap.Marker[] = []
+  for (const place of places) {
+    if (place.category === 'coffee' && !filters.coffee)
+      continue
+    if (place.category === 'park' && !filters.park)
+      continue
+
+    const marker = new AMap.Marker({
+      position: place.position,
+      title: place.name,
+      label: {
+        content: place.name,
+        direction: 'top',
+        offset: [0, -12],
+      },
+      extData: { id: place.id },
+    })
+    next.push(marker)
+  }
+
+  const previous = overlays.value
+  overlays.value = next
+  disposeMarkers(previous)
+}
+
+watch(
+  () => [filters.coffee, filters.park],
+  () => { void rebuildOverlays() },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  disposeMarkers(overlays.value)
+  overlays.value = []
+})
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Provide <code>VITE_AMAP_KEY</code> to view grouped overlays.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="11">
+          <AmapOverlayGroup :overlays="overlays" :visible="visible" />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <span>{{ overlays.length }} overlays</span>
+        <label>
+          <input v-model="filters.coffee" type="checkbox">
+          Coffee shops
+        </label>
+        <label>
+          <input v-model="filters.park" type="checkbox">
+          Parks
+        </label>
+        <label>
+          <input v-model="visible" type="checkbox">
+          Visible
+        </label>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/examples/ShapeEditorsDemo.vue
+++ b/docs/examples/ShapeEditorsDemo.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { loader } from '@amap-vue/shared'
+import { computed, onBeforeUnmount, ref, shallowRef } from 'vue'
+
+type TargetMode = 'instance' | 'id'
+
+const key = (import.meta as any).env?.VITE_AMAP_KEY as string | undefined
+if (key)
+  loader.config({ key })
+
+const hasKey = computed(() => Boolean(key))
+const center: [number, number] = [116.397, 39.908]
+
+const circleEditing = ref(false)
+const rectangleEditing = ref(false)
+const ellipseEditing = ref(false)
+
+const rectangle = shallowRef<AMap.Rectangle | null>(null)
+const ellipse = shallowRef<AMap.Ellipse | null>(null)
+
+const rectangleTargetMode = ref<TargetMode>('instance')
+const ellipseTargetMode = ref<TargetMode>('id')
+const eventLog = ref<string[]>([])
+
+function record(label: string) {
+  const time = new Date().toLocaleTimeString()
+  eventLog.value = [`${time} · ${label}`, ...eventLog.value].slice(0, 5)
+}
+
+async function handleReady(map: AMap.Map) {
+  if (!key)
+    return
+  const AMap = await loader.load()
+
+  const rect = new AMap.Rectangle({
+    bounds: new AMap.Bounds([116.36, 39.9], [116.41, 39.94]),
+    strokeColor: '#20c997',
+    strokeWeight: 2,
+    fillColor: 'rgba(32, 201, 151, 0.35)',
+    extData: { id: 'demo-rectangle' },
+  })
+  rect.setMap(map)
+  rectangle.value = rect
+
+  const ell = new AMap.Ellipse({
+    center: [116.406, 39.912],
+    radius: [900, 420],
+    strokeColor: '#fd7e14',
+    strokeWeight: 2,
+    fillColor: 'rgba(253, 126, 20, 0.3)',
+    extData: { id: 'demo-ellipse' },
+  })
+  ell.setMap(map)
+  ellipse.value = ell
+}
+
+const rectangleTarget = computed(() =>
+  rectangleTargetMode.value === 'instance' ? rectangle.value : 'demo-rectangle',
+)
+const ellipseTarget = computed(() =>
+  ellipseTargetMode.value === 'instance' ? ellipse.value : 'demo-ellipse',
+)
+
+onBeforeUnmount(() => {
+  rectangle.value?.destroy?.()
+  ellipse.value?.destroy?.()
+})
+</script>
+
+<template>
+  <div class="amap-demo">
+    <div v-if="!hasKey" class="amap-demo__placeholder">
+      Set <code>VITE_AMAP_KEY</code> to try the live editors.
+    </div>
+    <template v-else>
+      <div class="amap-demo__map">
+        <AmapMap :center="center" :zoom="12" @ready="handleReady">
+          <AmapCircle
+            :center="center"
+            :radius="600"
+            :ext-data="{ id: 'demo-circle' }"
+            :options="{ strokeColor: '#4b8bff', fillColor: 'rgba(75, 139, 255, 0.18)', strokeWeight: 2 }"
+          />
+
+          <AmapCircleEditor target="demo-circle" :active="circleEditing" @end="record('Circle edited')" />
+          <AmapRectangleEditor :target="rectangleTarget" :active="rectangleEditing" @end="record('Rectangle edited')" />
+          <AmapEllipseEditor :target="ellipseTarget" :active="ellipseEditing" @end="record('Ellipse edited')" />
+        </AmapMap>
+      </div>
+      <div class="amap-demo__toolbar">
+        <label>
+          <input v-model="circleEditing" type="checkbox">
+          Edit circle
+        </label>
+        <label>
+          <input v-model="rectangleEditing" type="checkbox">
+          Edit rectangle
+        </label>
+        <label>
+          Rectangle target
+          <select v-model="rectangleTargetMode">
+            <option value="instance">Overlay instance</option>
+            <option value="id">ExtData id</option>
+          </select>
+        </label>
+        <label>
+          <input v-model="ellipseEditing" type="checkbox">
+          Edit ellipse
+        </label>
+        <label>
+          Ellipse target
+          <select v-model="ellipseTargetMode">
+            <option value="id">ExtData id</option>
+            <option value="instance">Overlay instance</option>
+          </select>
+        </label>
+      </div>
+      <ul class="amap-demo__log">
+        <li v-if="!eventLog.length" class="muted">
+          Drag a vertex and release to record an event.
+        </li>
+        <li v-for="(message, index) in eventLog" :key="index">
+          {{ message }}
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>

--- a/docs/hooks/use-control.md
+++ b/docs/hooks/use-control.md
@@ -1,0 +1,44 @@
+# `useControl`, `useToolBar`, `useScale`, `useControlBar`, `useMapType`
+
+Drive JSAPI map controls from Vue state. The base `useControl` helper powers the specialised hooks exported by the kit, letting
+components react to prop changes and giving you direct access when you need custom behaviour.
+
+```ts
+import { useToolBar } from '@amap-vue/hooks'
+
+const control = useToolBar(() => map.value, () => ({
+  position: 'RT',
+  offset: [16, 16],
+  showZoomBar: true,
+}))
+
+control.show()
+control.setOptions({ liteStyle: true })
+```
+
+## Options
+
+The hooks accept the corresponding JSAPI options (for example `ToolBarOptions`) plus the shared keys below:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `visible` | `boolean` | Toggles the control without destroying it. |
+| `position` | `any` | Corner to anchor to (`'LT'`, `'RT'`, etc.). Passed through to the JSAPI control. |
+| `offset` | `PixelLike` | Pixel offset from the anchor corner. Arrays are converted to `AMap.Pixel`. |
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `control` | `ShallowRef<TControl \| null>` referencing the control instance. |
+| `show()` / `hide()` | Imperatively toggle visibility. |
+| `setPosition(position)` | Move the control to another corner. |
+| `setOffset(offset)` | Update the offset (accepts `PixelLike`). |
+| `setOptions(options)` | Forward arbitrary options to the JSAPI control. |
+| `destroy()` | Remove the control from the map and clean up listeners. |
+
+### Notes
+
+- The hook lazily loads the required plugin (`AMap.ToolBar`, `AMap.Scale`, etc.) the first time it runs. No manual `loader.config` call is required.
+- Controls automatically reattach themselves if the map reference changes (for example, when remounting `<AmapMap>`).
+- Prefer toggling the reactive `visible` option over conditional rendering so the control instance can be reused.

--- a/docs/hooks/use-editor.md
+++ b/docs/hooks/use-editor.md
@@ -1,0 +1,42 @@
+# `useEditorCircle`, `useEditorRectangle`, `useEditorEllipse`
+
+Wrap the JSAPI geometry editors in a composable. The hooks defer plugin loading until both the map and the target overlay are ready, keep the editor `active` state in sync with Vue, and expose helpers to switch targets on the fly.
+
+```ts
+import { useEditorCircle } from '@amap-vue/hooks'
+
+const circleEditor = useEditorCircle(() => map.value, () => ({
+  target: 'demo-circle',
+  active: isEditing.value,
+  radius: 12,
+}))
+
+circleEditor.on('end', () => {
+  console.log('Circle editing completed')
+})
+```
+
+## Options
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `target` | `AMap.Circle \| AMap.Rectangle \| AMap.Ellipse \| string \| null` | Overlay to edit. Strings resolve via `getId()` or `extData.id`. |
+| `active` | `boolean` | Whether the editor should be opened. |
+| `…options` | `Partial<AMap.CircleEditorOptions>` / `Partial<AMap.RectangleEditorOptions>` / `Partial<AMap.EllipseEditorOptions>` | Extra plugin configuration forwarded on creation. |
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `editor` | `ShallowRef<TEditor \| null>` referencing the editor instance. |
+| `open()` / `close()` | Imperatively toggle the editor. The reactive `active` option mirrors these calls. |
+| `setTarget(target)` | Switch to a different overlay instance or identifier. |
+| `getTarget()` | Retrieve the currently bound overlay (if any). |
+| `on(event, handler)` / `off(event, handler)` | Subscribe to JSAPI editor events (`adjust`, `end`, …). |
+| `destroy()` | Dispose of the editor and clear listeners. |
+
+### Notes
+
+- When a string `target` is provided the hook polls `map.getAllOverlays()` until the overlay appears, making it safe to pass IDs before overlays mount.
+- Updating the reactive options triggers `editor.setOptions` so you can tweak handles (e.g. `radius`, `borderWeight`) without recreating the editor.
+- Remember to destroy or deactivate the editor when removing the target overlay to prevent stale references.

--- a/docs/hooks/use-image-layer.md
+++ b/docs/hooks/use-image-layer.md
@@ -1,0 +1,50 @@
+# `useImageLayer`
+
+Create and control `AMap.ImageLayer` overlays from the Composition API. The hook watches reactive options, converts `BoundsLike`
+inputs, and exposes imperative setters for fine-grained tweaks.
+
+```ts
+import { useImageLayer } from '@amap-vue/hooks'
+
+const imageLayer = useImageLayer(() => map.value, () => ({
+  url: currentOverlay.value.url,
+  bounds: currentOverlay.value.bounds,
+  opacity: 0.7,
+  visible: showOverlay.value,
+}))
+
+watch(currentOverlay, (next) => {
+  imageLayer.setImageUrl(next.url)
+  imageLayer.setBounds(next.bounds)
+})
+```
+
+## Options
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `url` | `string` | Image URL to display. |
+| `bounds` | `BoundsLike` | Geographic bounds of the image. Arrays are converted to `AMap.Bounds`. |
+| `visible` | `boolean` | Show or hide the overlay. |
+| `opacity` | `number` | Blend the image against the base map. |
+| `zIndex` | `number` | Rendering order. |
+| `…options` | `Partial<AMap.ImageLayerOptions>` | Additional JSAPI options forwarded during creation. |
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.ImageLayer \| null>` referencing the image layer instance. |
+| `show()` / `hide()` | Toggle visibility without recreating the layer. |
+| `setImageUrl(url)` | Swap the image URL at runtime. |
+| `setBounds(bounds)` | Update the geographic bounds (`BoundsLike` accepted). |
+| `setOpacity(opacity)` | Adjust opacity dynamically. |
+| `setzIndex(zIndex)` | Raise or lower the layer relative to others. |
+| `setOptions(options)` | Forward arbitrary options to the JSAPI instance. |
+| `destroy()` | Remove the layer from the map and release references. |
+
+### Notes
+
+- The hook automatically requests the `AMap.ImageLayer` plugin the first time it runs.
+- When the map reference becomes `null` the layer detaches itself and reattaches once a new map instance is provided.
+- Bounds and offsets are normalised via the shared helpers from `@amap-vue/shared`, so you can safely pass array shorthand values.

--- a/docs/hooks/use-mass-markers.md
+++ b/docs/hooks/use-mass-markers.md
@@ -1,0 +1,41 @@
+# `useMassMarkers`
+
+Render thousands of lightweight markers using the JSAPI `MassMarks` plugin. The composable defers plugin loading, keeps the data
+set reactive, and exposes setters for styles and datasets.
+
+```ts
+import { useMassMarkers } from '@amap-vue/hooks'
+
+const mass = useMassMarkers(() => map.value, () => ({
+  data: points.value,
+  style: [
+    { url: '/images/cluster-blue.png', anchor: [6, 6], size: [12, 12] },
+    { url: '/images/cluster-orange.png', anchor: [10, 10], size: [20, 20] },
+  ],
+}))
+
+watch(points, value => mass.setData(value))
+```
+
+## Options
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `data` | `AMap.MassData[]` | Marker dataset (required). |
+| `style` | `AMap.MassMarkersStyleOptions \| AMap.MassMarkersStyleOptions[]` | Single or multi-style configuration. |
+| `options` | `Partial<AMap.MassMarkersOptions>` | Additional plugin options (opacity, zoom range, etc.). |
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `mass` | `ShallowRef<AMap.MassMarks \| null>` referencing the mass markers instance. |
+| `setData(data)` | Replace the dataset. |
+| `setStyle(style)` | Update the style definition. |
+| `destroy()` | Dispose of the plugin and release references. |
+
+### Notes
+
+- The hook automatically loads the `AMap.MassMarks` plugin; ensure your loader key is authorised for it.
+- When the map reference becomes `null` the mass markers detach from the map and reattach once the map is back online.
+- Use lightweight point data objects (no large payloads in `extData`) to keep updates cheap.

--- a/docs/hooks/use-overlay-group.md
+++ b/docs/hooks/use-overlay-group.md
@@ -1,0 +1,42 @@
+# `useOverlayGroup`
+
+Group and manage batches of overlays with a single composable. `useOverlayGroup` wraps `AMap.OverlayGroup`, queues updates when the overlays array changes, and gives you imperative helpers for high-volume operations.
+
+```ts
+const overlayGroup = useOverlayGroup(() => map.value, () => ({
+  overlays: markers.value,
+  visible: showGroup.value,
+  extData: { type: 'points-of-interest' },
+}))
+
+overlayGroup.addOverlay(createMarker(feature))
+overlayGroup.clearOverlays()
+```
+
+## Options
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `overlays` | `any[]` | Array of JSAPI overlays managed by the group. |
+| `visible` | `boolean` | Show or hide the group without destroying it. |
+| `extData` | `any` | Arbitrary metadata forwarded to the JSAPI group. |
+| `…options` | `Record<string, any>` | Additional constructor options passed straight through. |
+
+## Return value
+
+| Key | Description |
+| --- | --- |
+| `overlay` | `ShallowRef<AMap.OverlayGroup \| null>` referencing the overlay group instance. |
+| `show()` / `hide()` | Toggle group visibility. |
+| `addOverlay(overlay)` / `addOverlays(overlays)` | Append overlays to the group. |
+| `removeOverlay(overlay)` / `removeOverlays(overlays)` | Remove specific overlays from the group. |
+| `clearOverlays()` | Remove every overlay the group manages. |
+| `getOverlays()` | Snapshot of the current overlays array. |
+| `setExtData(extData)` | Update the group's metadata. |
+| `destroy()` | Dispose of the overlay group and detach listeners. |
+
+### Notes
+
+- The hook clears and readds overlays when the reactive `overlays` array changes, ensuring the JSAPI group stays in sync.
+- Combine the hook with the loader helpers to instantiate overlays lazily after the JSAPI bundle is ready.
+- Call `destroy()` or `clearOverlays()` when tearing down large datasets to avoid leaving detached markers on the map.


### PR DESCRIPTION
## Summary
- document `<AmapImageLayer>`, `<AmapOverlayGroup>`, and the geometry editors with runnable demos
- add guides for `useControl`, `useEditor`, `useImageLayer`, `useMassMarkers`, and `useOverlayGroup`
- extend the VitePress sidebar to surface the new component and hook pages

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0c3cadab48330bedc81a428396e68