### PR TITLE
docs: add campus basemap and info window recipes

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -110,7 +110,9 @@ export default defineConfig({
         {
           text: 'Recipes',
           items: [
+            { text: 'Campus Basemap', link: '/recipes/campus-basemap' },
             { text: 'Marker Clusters', link: '/recipes/marker-clusters' },
+            { text: 'Linked Info Windows', link: '/recipes/info-window-linking' },
             { text: 'Heatmap', link: '/recipes/heatmap' },
           ],
         },

--- a/docs/recipes/campus-basemap.md
+++ b/docs/recipes/campus-basemap.md
@@ -1,0 +1,62 @@
+# Campus Basemap
+
+Large campuses or parks often rely on a custom illustrated plan instead of the default tiles. Combine a neutral map style with an image layer so visitors keep the familiar JSAPI gestures while navigating a bespoke base map.
+
+```vue
+<script setup lang="ts">
+import { useImageLayer, useMap, useTileLayer } from '@amap-vue/hooks'
+import { ref } from 'vue'
+
+const container = ref<HTMLDivElement | null>(null)
+
+const { map, ready } = useMap(() => ({
+  container,
+  center: [121.49856, 31.23944],
+  zoom: 17,
+  viewMode: '3D',
+  mapStyle: 'amap://styles/whitesmoke',
+}))
+
+// Hide the default base tiles so the plan is unobstructed.
+useTileLayer(() => map.value, {
+  visible: false,
+})
+
+const campusLayer = useImageLayer(() => map.value, {
+  url: 'https://your-domain.example/assets/campus-plan.png',
+  bounds: [
+    [121.49693, 31.23863],
+    [121.50019, 31.24022],
+  ],
+  opacity: 0.85,
+})
+
+ready(() => {
+  campusLayer.show()
+})
+</script>
+
+<template>
+  <div ref="container" class="map" />
+</template>
+
+<style scoped>
+.map {
+  height: 360px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+</style>
+```
+
+Adjust the `bounds` to match the coordinates that enclose your artwork. Hosting the PNG or SVG under `public/` works well in Vite-based projects—swap the URL for `new URL('../assets/campus-plan.png', import.meta.url).href` when bundling locally.
+
+## Tips
+
+- Keep the original base map available in UI so users can switch back to satellite or vector tiles for orientation.
+- Because image layers do not reproject, ensure your plan uses the GCJ-02 coordinate system to avoid drifting from overlays.
+- Pair the plan with vector overlays (buildings, navigation paths) rendered by standard components so they stay interactive.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/docs/recipes/info-window-linking.md
+++ b/docs/recipes/info-window-linking.md
@@ -1,0 +1,137 @@
+# Linked Info Windows
+
+Synchronize a POI list with markers and info windows so hovering or clicking highlights a single location. The pattern relies on reactive state instead of imperative DOM queries, which keeps the UI in sync on both desktop and mobile.
+
+```vue
+<script setup lang="ts">
+import { useInfoWindow, useMap, useMarker } from '@amap-vue/hooks'
+import { ref, watch } from 'vue'
+
+interface Place {
+  id: number
+  name: string
+  address: string
+  position: [number, number]
+}
+
+const places: Place[] = [
+  { id: 1, name: 'North Gate Café', address: '12 Chaoyangmen W St', position: [116.396923, 39.90816] },
+  { id: 2, name: 'Library', address: '88 Workers Stadium Rd', position: [116.40021, 39.90986] },
+  { id: 3, name: 'Rooftop Garden', address: '22 Jinbao St', position: [116.40137, 39.90745] },
+]
+
+const container = ref<HTMLDivElement | null>(null)
+const activeId = ref<number | null>(places[0]?.id ?? null)
+
+const { map, ready } = useMap(() => ({
+  container,
+  center: places[0]?.position ?? [116.397428, 39.90923],
+  zoom: 14,
+}))
+
+const markers = places.map(place =>
+  useMarker(() => map.value, {
+    position: place.position,
+    extData: place,
+    title: place.name,
+  }),
+)
+
+const infoWindow = useInfoWindow(() => map.value, {
+  offset: [0, -28],
+  isCustom: false,
+})
+
+function focusPlace(id: number) {
+  activeId.value = id
+}
+
+watch(activeId, (id) => {
+  if (id == null) {
+    infoWindow.close()
+    return
+  }
+
+  const place = places.find(item => item.id === id)
+  if (!place)
+    return
+
+  infoWindow.setContent(
+    `<div class="poi-card"><h4>${place.name}</h4><p>${place.address}</p></div>`,
+  )
+  infoWindow.setPosition(place.position)
+  infoWindow.open()
+}, { immediate: true })
+
+ready(() => {
+  markers.forEach((marker, index) => {
+    marker.on('click', () => focusPlace(places[index].id))
+  })
+})
+</script>
+
+<template>
+  <div class="layout">
+    <ul class="poi-list">
+      <li
+        v-for="place in places"
+        :key="place.id"
+        :class="{ active: place.id === activeId }"
+        @mouseenter="focusPlace(place.id)"
+        @focusin="focusPlace(place.id)"
+      >
+        <h4>{{ place.name }}</h4>
+        <p>{{ place.address }}</p>
+      </li>
+    </ul>
+    <div ref="container" class="map" />
+  </div>
+</template>
+
+<style scoped>
+.layout {
+  display: flex;
+  gap: 16px;
+}
+
+.poi-list {
+  width: 220px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.poi-list li {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #f6f8fb;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.poi-list li.active {
+  background: #e3f2ff;
+}
+
+.map {
+  flex: 1;
+  height: 360px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+</style>
+```
+
+The watcher keeps the info window and marker in sync regardless of whether the user hovers over the list, taps a marker, or navigates with keyboard focus. Remember to call `infoWindow.close()` when the selection becomes `null` to hide the overlay.
+
+## Tips
+
+- Store additional metadata in `extData` so clicking the marker can update other UI such as detail panels.
+- Debounce `focusPlace` when syncing with fast-moving inputs (like list scrolling) to avoid spamming info window updates.
+- On mobile, trigger `focusPlace` on `click` or `touchstart` instead of hover-only events so the interaction works without a mouse.
+
+### StackBlitz
+
+[Open the example project](https://stackblitz.com/github/your-org/amap-vue-kit/tree/main/examples/basic)

--- a/todo.md
+++ b/todo.md
@@ -293,7 +293,7 @@ amap-vue-kit/
 * [ ] Hooks（与组件一一对应）
   * [x] TileLayer / Traffic / RoadNet / Satellite hooks 文档
   * [ ] Advanced（大数据点/性能、ImageLayer、轨迹动画、主题样式）
-  * [ ] Recipes（园区底图、聚合、信息窗联动）
+* [x] Recipes（园区底图、聚合、信息窗联动）
   * [ ] FAQ（Key、CSP、地图不显示排错）
   * [ ] Changelog（changesets）
 * [ ] 每个页面都包含可运行示例（docs 内嵌 SFC + `ClientOnly`）


### PR DESCRIPTION
## Summary
- add a campus basemap recipe that layers custom artwork over hidden base tiles
- document a linked info window pattern that keeps a POI list and markers in sync
- expose the new recipes in the VitePress sidebar and mark the roadmap item complete

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f12947c48330bd7627deac6dfd16